### PR TITLE
[Chore]: Resolve phpstan archived errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "orchestra/testbench": "^10.4",
         "pestphp/pest-plugin-laravel": "^3.2",
         "friendsofphp/php-cs-fixer": "^3.75",
-        "orrison/meliorstan": "^0.3.2"
+        "orrison/meliorstan": "^0.3.2",
+        "larastan/larastan": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1f098da67901eaa98a8b3307e34bf6c1",
+    "content-hash": "7726fe3646d6fd90d6468a886b8b0efe",
     "packages": [
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -8739,6 +8739,47 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
+            "name": "iamcal/sql-parser",
+            "version": "v0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/iamcal/SQLParser.git",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/iamcal/SQLParser/zipball/610392f38de49a44dab08dc1659960a29874c4b8",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^1.0",
+                "phpunit/phpunit": "^5|^6|^7|^8|^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "iamcal\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cal Henderson",
+                    "email": "cal@iamcal.com"
+                }
+            ],
+            "description": "MySQL schema parser",
+            "support": {
+                "issues": "https://github.com/iamcal/SQLParser/issues",
+                "source": "https://github.com/iamcal/SQLParser/tree/v0.7"
+            },
+            "time": "2026-01-28T22:20:33+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "2.1.1",
             "source": {
@@ -8797,6 +8838,96 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "larastan/larastan",
+            "version": "v3.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "64a52bcc5347c89fdf131cb59f96ebfbc8d1ad65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/64a52bcc5347c89fdf131cb59f96ebfbc8d1ad65",
+                "reference": "64a52bcc5347c89fdf131cb59f96ebfbc8d1ad65",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "iamcal/sql-parser": "^0.7.0",
+                "illuminate/console": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/container": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/contracts": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/database": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/http": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/pipeline": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/support": "^11.44.2 || ^12.4.1 || ^13",
+                "php": "^8.2",
+                "phpstan/phpstan": "^2.1.32"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^13",
+                "laravel/framework": "^11.44.2 || ^12.7.2 || ^13",
+                "mockery/mockery": "^1.6.12",
+                "nikic/php-parser": "^5.4",
+                "orchestra/canvas": "^v9.2.2 || ^10.0.1 || ^11",
+                "orchestra/testbench-core": "^9.12.0 || ^10.1 || ^11",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",
+                "phpmyadmin/sql-parser": "Install to enable Larastan's optional phpMyAdmin-based SQL parser automatically"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Larastan\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Can Vural",
+                    "email": "can9119@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/larastan/larastan/issues",
+                "source": "https://github.com/larastan/larastan/tree/v3.9.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-20T12:07:12+00:00"
         },
         {
             "name": "laravel/pail",

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -1,0 +1,5 @@
+services:
+    -
+        class: CanyonGBS\Common\Support\PHPStan\CanBeArchivedExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -3,3 +3,7 @@ services:
         class: CanyonGBS\Common\Support\PHPStan\CanBeArchivedExtension
         tags:
             - phpstan.broker.methodsClassReflectionExtension
+    -
+        class: CanyonGBS\Common\Support\PHPStan\CanBeArchivedRelationExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 includes:
     - ./vendor/pestphp/pest/extension.neon
     - ./vendor/orrison/meliorstan/config/extension.neon
+    - phpstan-extension.neon
 
 rules:
     - Orrison\MeliorStan\Rules\BooleanGetMethodName\BooleanGetMethodNameRule

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,7 @@
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix=".php">./tests/</directory>
+            <exclude>./tests/PHPStan/Fixtures</exclude>
         </testsuite>
     </testsuites>
     <source>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,8 +6,7 @@
 >
     <testsuites>
         <testsuite name="Test Suite">
-            <directory suffix=".php">./tests/</directory>
-            <exclude>./tests/PHPStan/Fixtures</exclude>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
     <source>

--- a/src/Support/PHPStan/CanBeArchivedExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedExtension.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+declare(strict_types=1);
+
+namespace CanyonGBS\Common\Support\PHPStan;
+
+use CanyonGBS\Common\Models\Concerns\CanBeArchived;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Larastan\Larastan\Reflection\EloquentBuilderMethodReflection;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Generic\TemplateObjectType;
+use PHPStan\Type\ObjectType;
+
+use function array_key_exists;
+use function array_map;
+use function array_merge;
+use function in_array;
+
+final class CanBeArchivedExtension implements MethodsClassReflectionExtension
+{
+    private const METHODS = ['withoutArchived', 'onlyArchived', 'withoutArchivedAndUnused', 'archive', 'unarchive'];
+
+    /** @var array<string, MethodReflection> */
+    private array $cache = [];
+
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if (array_key_exists($classReflection->getCacheKey() . '-' . $methodName, $this->cache)) {
+            return true;
+        }
+
+        $methodReflection = $this->findMethod($classReflection, $methodName);
+
+        if ($methodReflection !== null) {
+            $this->cache[$classReflection->getCacheKey() . '-' . $methodName] = $methodReflection;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        return $this->cache[$classReflection->getCacheKey() . '-' . $methodName];
+    }
+
+    private function findMethod(ClassReflection $classReflection, string $methodName): MethodReflection|null
+    {
+        if (! $classReflection->is(EloquentBuilder::class)) {
+            return null;
+        }
+
+        if (! in_array($methodName, self::METHODS, true)) {
+            return null;
+        }
+
+        $loopReflection = $classReflection;
+
+        do {
+            $modelType = $loopReflection->getActiveTemplateTypeMap()->getType('TModel');
+
+            if ($modelType !== null) {
+                break;
+            }
+
+            $loopReflection = $loopReflection->getParentClass();
+        } while ($loopReflection !== null);
+
+        if ($modelType === null) {
+            return new EloquentBuilderMethodReflection(
+                $methodName,
+                $classReflection,
+                [],
+                new ObjectType($classReflection->getName()),
+            );
+        }
+
+        if ($modelType instanceof TemplateObjectType) {
+            $modelType = $modelType->getBound();
+        }
+
+        if (! array_key_exists(
+            CanBeArchived::class,
+            array_merge(...array_map(
+                static fn (ClassReflection $classRef) => $classRef->getTraits(true),
+                $modelType->getObjectClassReflections(),
+            )),
+        )) {
+            return null;
+        }
+
+        return new EloquentBuilderMethodReflection(
+            $methodName,
+            $classReflection,
+            [],
+            new GenericObjectType($classReflection->getName(), [$modelType]),
+        );
+    }
+}

--- a/src/Support/PHPStan/CanBeArchivedExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedExtension.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/src/Support/PHPStan/CanBeArchivedExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedExtension.php
@@ -39,8 +39,6 @@ declare(strict_types = 1);
 namespace CanyonGBS\Common\Support\PHPStan;
 
 use function array_key_exists;
-use function array_map;
-use function array_merge;
 
 use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -113,14 +111,16 @@ class CanBeArchivedExtension implements MethodsClassReflectionExtension
             $modelType = $modelType->getBound();
         }
 
-        if (! array_key_exists(
-            CanBeArchived::class,
-            array_merge(...array_map(
-                static fn (ClassReflection $classRef) => $classRef->getTraits(true),
-                $modelType->getObjectClassReflections(),
-            )),
-        )) {
+        $reflections = $modelType->getObjectClassReflections();
+
+        if ($reflections === []) {
             return null;
+        }
+
+        foreach ($reflections as $reflection) {
+            if (! array_key_exists(CanBeArchived::class, $reflection->getTraits(true))) {
+                return null;
+            }
         }
 
         return new EloquentBuilderMethodReflection(

--- a/src/Support/PHPStan/CanBeArchivedExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedExtension.php
@@ -34,23 +34,25 @@
 </COPYRIGHT>
 */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace CanyonGBS\Common\Support\PHPStan;
 
+use function array_key_exists;
+use function array_map;
+use function array_merge;
+
 use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+
+use function in_array;
+
 use Larastan\Larastan\Reflection\EloquentBuilderMethodReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateObjectType;
-
-use function array_key_exists;
-use function array_map;
-use function array_merge;
-use function in_array;
 
 class CanBeArchivedExtension implements MethodsClassReflectionExtension
 {

--- a/src/Support/PHPStan/CanBeArchivedExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedExtension.php
@@ -46,7 +46,6 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateObjectType;
-use PHPStan\Type\ObjectType;
 
 use function array_key_exists;
 use function array_map;
@@ -105,12 +104,7 @@ final class CanBeArchivedExtension implements MethodsClassReflectionExtension
         } while ($loopReflection !== null);
 
         if ($modelType === null) {
-            return new EloquentBuilderMethodReflection(
-                $methodName,
-                $classReflection,
-                [],
-                new ObjectType($classReflection->getName()),
-            );
+            return null;
         }
 
         if ($modelType instanceof TemplateObjectType) {

--- a/src/Support/PHPStan/CanBeArchivedExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedExtension.php
@@ -52,12 +52,12 @@ use function array_map;
 use function array_merge;
 use function in_array;
 
-final class CanBeArchivedExtension implements MethodsClassReflectionExtension
+class CanBeArchivedExtension implements MethodsClassReflectionExtension
 {
-    private const METHODS = ['withoutArchived', 'onlyArchived', 'withoutArchivedAndUnused', 'archive', 'unarchive'];
+    protected const METHODS = ['withoutArchived', 'onlyArchived', 'withoutArchivedAndUnused', 'archive', 'unarchive'];
 
     /** @var array<string, MethodReflection> */
-    private array $cache = [];
+    protected array $cache = [];
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
@@ -81,7 +81,7 @@ final class CanBeArchivedExtension implements MethodsClassReflectionExtension
         return $this->cache[$classReflection->getCacheKey() . '-' . $methodName];
     }
 
-    private function findMethod(ClassReflection $classReflection, string $methodName): MethodReflection|null
+    protected function findMethod(ClassReflection $classReflection, string $methodName): MethodReflection|null
     {
         if (! $classReflection->is(EloquentBuilder::class)) {
             return null;

--- a/src/Support/PHPStan/CanBeArchivedRelationExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedRelationExtension.php
@@ -34,30 +34,32 @@
 </COPYRIGHT>
 */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace CanyonGBS\Common\Support\PHPStan;
 
-use function array_key_exists;
-
+use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Relations\Relation;
-
-use function in_array;
-
 use Larastan\Larastan\Reflection\EloquentBuilderMethodReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Type\Generic\TemplateObjectType;
 use PHPStan\Type\ThisType;
+
+use function in_array;
+use function array_key_exists;
+use function array_map;
+use function array_merge;
+use function in_array;
 
 /**
  * Recognizes CanBeArchived methods (withoutArchived, onlyArchived, etc.) on
- * Eloquent Relation classes. Because PHPStan's MethodsClassReflectionExtension
- * receives the class definition (not a parameterized type), concrete generic
- * type arguments are not available — we cannot verify whether the related model
- * actually uses the CanBeArchived trait. This is the same limitation that
- * Larastan's built-in SoftDeletes support has on relations. We accept the
- * methods unconditionally on any Relation to avoid false positives.
+ * Eloquent Relation classes. When the relation has a concrete generic return
+ * type (e.g., `@return BelongsTo<Project, $this>`), the extension can verify
+ * whether the related model uses the CanBeArchived trait. When the concrete
+ * type is not available (missing docblock or unresolvable generics), the
+ * methods are not recognized.
  */
 class CanBeArchivedRelationExtension implements MethodsClassReflectionExtension
 {
@@ -95,6 +97,32 @@ class CanBeArchivedRelationExtension implements MethodsClassReflectionExtension
         }
 
         if (! in_array($methodName, self::METHODS, true)) {
+            return null;
+        }
+
+        $relatedModel = $classReflection->getActiveTemplateTypeMap()->getType('TRelatedModel');
+
+        if ($relatedModel === null) {
+            return null;
+        }
+
+        if ($relatedModel instanceof TemplateObjectType) {
+            $relatedModel = $relatedModel->getBound();
+        }
+
+        $reflections = $relatedModel->getObjectClassReflections();
+
+        if ($reflections === []) {
+            return null;
+        }
+
+        if (! array_key_exists(
+            CanBeArchived::class,
+            array_merge(...array_map(
+                static fn (ClassReflection $classRef) => $classRef->getTraits(true),
+                $reflections,
+            )),
+        )) {
             return null;
         }
 

--- a/src/Support/PHPStan/CanBeArchivedRelationExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedRelationExtension.php
@@ -34,19 +34,21 @@
 </COPYRIGHT>
 */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace CanyonGBS\Common\Support\PHPStan;
 
+use function array_key_exists;
+
 use Illuminate\Database\Eloquent\Relations\Relation;
+
+use function in_array;
+
 use Larastan\Larastan\Reflection\EloquentBuilderMethodReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Type\ThisType;
-
-use function array_key_exists;
-use function in_array;
 
 /**
  * Recognizes CanBeArchived methods (withoutArchived, onlyArchived, etc.) on

--- a/src/Support/PHPStan/CanBeArchivedRelationExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedRelationExtension.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/src/Support/PHPStan/CanBeArchivedRelationExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedRelationExtension.php
@@ -46,7 +46,6 @@ use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
 use function in_array;
-use function in_array;
 
 use Larastan\Larastan\Reflection\EloquentBuilderMethodReflection;
 use PHPStan\Reflection\ClassReflection;

--- a/src/Support/PHPStan/CanBeArchivedRelationExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedRelationExtension.php
@@ -39,8 +39,6 @@ declare(strict_types = 1);
 namespace CanyonGBS\Common\Support\PHPStan;
 
 use function array_key_exists;
-use function array_map;
-use function array_merge;
 
 use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -117,14 +115,10 @@ class CanBeArchivedRelationExtension implements MethodsClassReflectionExtension
             return null;
         }
 
-        if (! array_key_exists(
-            CanBeArchived::class,
-            array_merge(...array_map(
-                static fn (ClassReflection $classRef) => $classRef->getTraits(true),
-                $reflections,
-            )),
-        )) {
-            return null;
+        foreach ($reflections as $reflection) {
+            if (! array_key_exists(CanBeArchived::class, $reflection->getTraits(true))) {
+                return null;
+            }
         }
 
         return new EloquentBuilderMethodReflection(

--- a/src/Support/PHPStan/CanBeArchivedRelationExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedRelationExtension.php
@@ -34,24 +34,26 @@
 </COPYRIGHT>
 */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace CanyonGBS\Common\Support\PHPStan;
 
+use function array_key_exists;
+use function array_map;
+use function array_merge;
+
 use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Relations\Relation;
+
+use function in_array;
+use function in_array;
+
 use Larastan\Larastan\Reflection\EloquentBuilderMethodReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Type\Generic\TemplateObjectType;
 use PHPStan\Type\ThisType;
-
-use function in_array;
-use function array_key_exists;
-use function array_map;
-use function array_merge;
-use function in_array;
 
 /**
  * Recognizes CanBeArchived methods (withoutArchived, onlyArchived, etc.) on

--- a/src/Support/PHPStan/CanBeArchivedRelationExtension.php
+++ b/src/Support/PHPStan/CanBeArchivedRelationExtension.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+declare(strict_types=1);
+
+namespace CanyonGBS\Common\Support\PHPStan;
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Larastan\Larastan\Reflection\EloquentBuilderMethodReflection;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Type\ThisType;
+
+use function array_key_exists;
+use function in_array;
+
+/**
+ * Recognizes CanBeArchived methods (withoutArchived, onlyArchived, etc.) on
+ * Eloquent Relation classes. Because PHPStan's MethodsClassReflectionExtension
+ * receives the class definition (not a parameterized type), concrete generic
+ * type arguments are not available — we cannot verify whether the related model
+ * actually uses the CanBeArchived trait. This is the same limitation that
+ * Larastan's built-in SoftDeletes support has on relations. We accept the
+ * methods unconditionally on any Relation to avoid false positives.
+ */
+class CanBeArchivedRelationExtension implements MethodsClassReflectionExtension
+{
+    protected const METHODS = ['withoutArchived', 'onlyArchived', 'withoutArchivedAndUnused', 'archive', 'unarchive'];
+
+    /** @var array<string, MethodReflection> */
+    protected array $cache = [];
+
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if (array_key_exists($classReflection->getCacheKey() . '-' . $methodName, $this->cache)) {
+            return true;
+        }
+
+        $methodReflection = $this->findMethod($classReflection, $methodName);
+
+        if ($methodReflection !== null) {
+            $this->cache[$classReflection->getCacheKey() . '-' . $methodName] = $methodReflection;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        return $this->cache[$classReflection->getCacheKey() . '-' . $methodName];
+    }
+
+    protected function findMethod(ClassReflection $classReflection, string $methodName): MethodReflection|null
+    {
+        if (! $classReflection->is(Relation::class)) {
+            return null;
+        }
+
+        if (! in_array($methodName, self::METHODS, true)) {
+            return null;
+        }
+
+        return new EloquentBuilderMethodReflection(
+            $methodName,
+            $classReflection,
+            [],
+            new ThisType($classReflection),
+        );
+    }
+}

--- a/tests/Mapper/AbstractMapperTest.php
+++ b/tests/Mapper/AbstractMapperTest.php
@@ -36,7 +36,7 @@
 
 use function PHPUnit\Framework\assertEquals;
 
-function testMap(array $input, array $expectation, array $arguments = [], callable $getMapper): void
+function testMap(array $input, array $expectation, callable $getMapper, array $arguments = []): void
 {
     $mapper = call_user_func_array($getMapper, $arguments);
     assertEquals($expectation, $mapper->map($input));

--- a/tests/PHPStan/CanBeArchivedExtensionTest.php
+++ b/tests/PHPStan/CanBeArchivedExtensionTest.php
@@ -55,6 +55,15 @@ it('recognizes archive methods on a relation to a model with CanBeArchived', fun
     expect($result['exitCode'])->toBe(0, "PHPStan should not report errors for archive methods on a relation.\nOutput: {$result['output']}");
 });
 
+it('reports errors for archive methods on a relation to a model without CanBeArchived', function () {
+    $result = runPhpStan('tests/PHPStan/Fixtures/NonArchivedRelationFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('withoutArchived');
+    expect($result['output'])->toContain('onlyArchived');
+    expect($result['output'])->toContain('withoutArchivedAndUnused');
+});
+
 /**
  * @return array{exitCode: int, output: string}
  */

--- a/tests/PHPStan/CanBeArchivedExtensionTest.php
+++ b/tests/PHPStan/CanBeArchivedExtensionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('recognizes archive methods on a builder for a model with CanBeArchived', function () {
+    $result = runPhpStan('tests/PHPStan/Fixtures/CanBeArchivedModelFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report errors for archive methods on a model with CanBeArchived.\nOutput: {$result['output']}");
+});
+
+it('reports errors for archive methods on a builder for a model without CanBeArchived', function () {
+    $result = runPhpStan('tests/PHPStan/Fixtures/NonArchivedModelFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('withoutArchived');
+    expect($result['output'])->toContain('onlyArchived');
+    expect($result['output'])->toContain('withoutArchivedAndUnused');
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStan(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=table --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}

--- a/tests/PHPStan/CanBeArchivedExtensionTest.php
+++ b/tests/PHPStan/CanBeArchivedExtensionTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/tests/PHPStan/CanBeArchivedExtensionTest.php
+++ b/tests/PHPStan/CanBeArchivedExtensionTest.php
@@ -74,7 +74,7 @@ function runPhpStan(string $filePath): array
     $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
     $file = escapeshellarg($filePath);
 
-    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=table --no-progress 2>&1";
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
 
     exec($command, $outputLines, $exitCode);
 

--- a/tests/PHPStan/CanBeArchivedExtensionTest.php
+++ b/tests/PHPStan/CanBeArchivedExtensionTest.php
@@ -49,6 +49,12 @@ it('reports errors for archive methods on a builder for a model without CanBeArc
     expect($result['output'])->toContain('withoutArchivedAndUnused');
 });
 
+it('recognizes archive methods on a relation to a model with CanBeArchived', function () {
+    $result = runPhpStan('tests/PHPStan/Fixtures/CanBeArchivedRelationFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report errors for archive methods on a relation.\nOutput: {$result['output']}");
+});
+
 /**
  * @return array{exitCode: int, output: string}
  */

--- a/tests/PHPStan/Fixtures/CanBeArchivedModelFixture.php
+++ b/tests/PHPStan/Fixtures/CanBeArchivedModelFixture.php
@@ -34,7 +34,7 @@
 </COPYRIGHT>
 */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 use Workbench\App\Models\Project;
 

--- a/tests/PHPStan/Fixtures/CanBeArchivedModelFixture.php
+++ b/tests/PHPStan/Fixtures/CanBeArchivedModelFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 declare(strict_types=1);
 
 use Workbench\App\Models\Project;

--- a/tests/PHPStan/Fixtures/CanBeArchivedModelFixture.php
+++ b/tests/PHPStan/Fixtures/CanBeArchivedModelFixture.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Workbench\App\Models\Project;
+
+$query = Project::query();
+
+$query->withoutArchived();
+$query->onlyArchived();
+$query->withoutArchivedAndUnused();

--- a/tests/PHPStan/Fixtures/CanBeArchivedRelationFixture.php
+++ b/tests/PHPStan/Fixtures/CanBeArchivedRelationFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Workbench\App\Models\Task;
+
+$task = new Task();
+$task->project()->withoutArchived();
+$task->project()->onlyArchived();
+$task->project()->withoutArchivedAndUnused();

--- a/tests/PHPStan/Fixtures/CanBeArchivedRelationFixture.php
+++ b/tests/PHPStan/Fixtures/CanBeArchivedRelationFixture.php
@@ -36,9 +36,49 @@
 
 declare(strict_types = 1);
 
+use Workbench\App\Models\Image;
+use Workbench\App\Models\Project;
 use Workbench\App\Models\Task;
 
+// BelongsTo: Task->project() where Project HAS CanBeArchived
 $task = new Task();
 $task->project()->withoutArchived();
 $task->project()->onlyArchived();
 $task->project()->withoutArchivedAndUnused();
+
+// HasOne: Task->deployment() where Deployment HAS CanBeArchived
+$task->deployment()->withoutArchived();
+$task->deployment()->onlyArchived();
+$task->deployment()->withoutArchivedAndUnused();
+
+// BelongsToMany: Task->tags() where Tag HAS CanBeArchived
+$task->tags()->withoutArchived();
+$task->tags()->onlyArchived();
+$task->tags()->withoutArchivedAndUnused();
+
+// MorphOne: Project->image() where Image HAS CanBeArchived
+$project = new Project();
+$project->image()->withoutArchived();
+$project->image()->onlyArchived();
+$project->image()->withoutArchivedAndUnused();
+
+// MorphToMany: Project->tags() where Tag HAS CanBeArchived
+$project->tags()->withoutArchived();
+$project->tags()->onlyArchived();
+$project->tags()->withoutArchivedAndUnused();
+
+// HasOneThrough: Project->latestDeployment() where Deployment HAS CanBeArchived
+$project->latestDeployment()->withoutArchived();
+$project->latestDeployment()->onlyArchived();
+$project->latestDeployment()->withoutArchivedAndUnused();
+
+// HasManyThrough: Project->deployments() where Deployment HAS CanBeArchived
+$project->deployments()->withoutArchived();
+$project->deployments()->onlyArchived();
+$project->deployments()->withoutArchivedAndUnused();
+
+// MorphTo (all models in union have trait): Image->imageable() where MorphTo<Project|Image>
+$image = new Image();
+$image->imageable()->withoutArchived();
+$image->imageable()->onlyArchived();
+$image->imageable()->withoutArchivedAndUnused();

--- a/tests/PHPStan/Fixtures/CanBeArchivedRelationFixture.php
+++ b/tests/PHPStan/Fixtures/CanBeArchivedRelationFixture.php
@@ -34,7 +34,7 @@
 </COPYRIGHT>
 */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 use Workbench\App\Models\Task;
 

--- a/tests/PHPStan/Fixtures/CanBeArchivedRelationFixture.php
+++ b/tests/PHPStan/Fixtures/CanBeArchivedRelationFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 declare(strict_types=1);
 
 use Workbench\App\Models\Task;

--- a/tests/PHPStan/Fixtures/NonArchivedModelFixture.php
+++ b/tests/PHPStan/Fixtures/NonArchivedModelFixture.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Workbench\App\Models\Task;
+
+$query = Task::query();
+
+$query->withoutArchived();
+$query->onlyArchived();
+$query->withoutArchivedAndUnused();

--- a/tests/PHPStan/Fixtures/NonArchivedModelFixture.php
+++ b/tests/PHPStan/Fixtures/NonArchivedModelFixture.php
@@ -34,7 +34,7 @@
 </COPYRIGHT>
 */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 use Workbench\App\Models\Task;
 

--- a/tests/PHPStan/Fixtures/NonArchivedModelFixture.php
+++ b/tests/PHPStan/Fixtures/NonArchivedModelFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 declare(strict_types=1);
 
 use Workbench\App\Models\Task;

--- a/tests/PHPStan/Fixtures/NonArchivedRelationFixture.php
+++ b/tests/PHPStan/Fixtures/NonArchivedRelationFixture.php
@@ -36,9 +36,64 @@
 
 declare(strict_types = 1);
 
+use Workbench\App\Models\Category;
+use Workbench\App\Models\Comment;
+use Workbench\App\Models\Deployment;
 use Workbench\App\Models\Project;
+use Workbench\App\Models\Tag;
 
+// HasMany: Project->tasks() where Task LACKS CanBeArchived
 $project = new Project();
 $project->tasks()->withoutArchived();
 $project->tasks()->onlyArchived();
 $project->tasks()->withoutArchivedAndUnused();
+
+// HasOne: Project->latestTask() where Task LACKS CanBeArchived
+$project->latestTask()->withoutArchived();
+$project->latestTask()->onlyArchived();
+$project->latestTask()->withoutArchivedAndUnused();
+
+// MorphMany: Project->comments() where Comment LACKS CanBeArchived
+$project->comments()->withoutArchived();
+$project->comments()->onlyArchived();
+$project->comments()->withoutArchivedAndUnused();
+
+// BelongsTo: Deployment->task() where Task LACKS CanBeArchived
+$deployment = new Deployment();
+$deployment->task()->withoutArchived();
+$deployment->task()->onlyArchived();
+$deployment->task()->withoutArchivedAndUnused();
+
+// HasOneThrough: Category->latestReview() where Review LACKS CanBeArchived
+$category = new Category();
+$category->latestReview()->withoutArchived();
+$category->latestReview()->onlyArchived();
+$category->latestReview()->withoutArchivedAndUnused();
+
+// HasManyThrough: Category->reviews() where Review LACKS CanBeArchived
+$category->reviews()->withoutArchived();
+$category->reviews()->onlyArchived();
+$category->reviews()->withoutArchivedAndUnused();
+
+// BelongsToMany: Tag->tasks() where Task LACKS CanBeArchived
+$tag = new Tag();
+$tag->tasks()->withoutArchived();
+$tag->tasks()->onlyArchived();
+$tag->tasks()->withoutArchivedAndUnused();
+
+// MorphOne: Tag->comment() where Comment LACKS CanBeArchived
+$tag->comment()->withoutArchived();
+$tag->comment()->onlyArchived();
+$tag->comment()->withoutArchivedAndUnused();
+
+// MorphMany (negative using Tag->images is positive, so use separate):
+// MorphToMany: Tag->reviews() where Review LACKS CanBeArchived
+$tag->reviews()->withoutArchived();
+$tag->reviews()->onlyArchived();
+$tag->reviews()->withoutArchivedAndUnused();
+
+// MorphTo (mixed union): Comment->commentable() where MorphTo<Project|Task> — Task LACKS CanBeArchived
+$comment = new Comment();
+$comment->commentable()->withoutArchived();
+$comment->commentable()->onlyArchived();
+$comment->commentable()->withoutArchivedAndUnused();

--- a/tests/PHPStan/Fixtures/NonArchivedRelationFixture.php
+++ b/tests/PHPStan/Fixtures/NonArchivedRelationFixture.php
@@ -34,7 +34,7 @@
 </COPYRIGHT>
 */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 use Workbench\App\Models\Project;
 

--- a/tests/PHPStan/Fixtures/NonArchivedRelationFixture.php
+++ b/tests/PHPStan/Fixtures/NonArchivedRelationFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 declare(strict_types=1);
 
 use Workbench\App\Models\Project;

--- a/tests/PHPStan/Fixtures/NonArchivedRelationFixture.php
+++ b/tests/PHPStan/Fixtures/NonArchivedRelationFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Workbench\App\Models\Project;
+
+$project = new Project();
+$project->tasks()->withoutArchived();
+$project->tasks()->onlyArchived();
+$project->tasks()->withoutArchivedAndUnused();

--- a/tests/PHPStan/phpstan-test.neon
+++ b/tests/PHPStan/phpstan-test.neon
@@ -1,4 +1,5 @@
 includes:
+    - ../../vendor/larastan/larastan/extension.neon
     - ../../phpstan-extension.neon
 
 parameters:

--- a/tests/PHPStan/phpstan-test.neon
+++ b/tests/PHPStan/phpstan-test.neon
@@ -1,5 +1,4 @@
 includes:
-    - ../../vendor/larastan/larastan/extension.neon
     - ../../phpstan-extension.neon
 
 parameters:

--- a/tests/PHPStan/phpstan-test.neon
+++ b/tests/PHPStan/phpstan-test.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../phpstan-extension.neon
+
+parameters:
+    level: 6

--- a/workbench/app/Models/Article.php
+++ b/workbench/app/Models/Article.php
@@ -42,8 +42,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Workbench\App\Models\Category;
-use Workbench\App\Models\Review;
 use Workbench\Database\Factories\ArticleFactory;
 
 class Article extends Model

--- a/workbench/app/Models/Article.php
+++ b/workbench/app/Models/Article.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/app/Models/Article.php
+++ b/workbench/app/Models/Article.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -40,21 +40,13 @@ use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasManyThrough;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Database\Eloquent\Relations\HasOneThrough;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Database\Eloquent\Relations\MorphOne;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Workbench\App\Models\Comment;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Image;
-use Workbench\App\Models\Tag;
-use Workbench\App\Models\Task;
-use Workbench\Database\Factories\ProjectFactory;
+use Workbench\App\Models\Category;
+use Workbench\App\Models\Review;
+use Workbench\Database\Factories\ArticleFactory;
 
-class Project extends Model
+class Article extends Model
 {
     use CanBeArchived;
     use HasFactory;
@@ -62,68 +54,28 @@ class Project extends Model
     protected $guarded = [];
 
     /**
-     * @return HasMany<Task, $this>
+     * @return BelongsTo<Category, $this>
      */
-    public function tasks(): HasMany
+    public function category(): BelongsTo
     {
-        return $this->hasMany(Task::class);
+        return $this->belongsTo(Category::class);
     }
 
     /**
-     * @return HasOne<Task, $this>
+     * @return HasMany<Review, $this>
      */
-    public function latestTask(): HasOne
+    public function reviews(): HasMany
     {
-        return $this->hasOne(Task::class)->latestOfMany();
-    }
-
-    /**
-     * @return MorphOne<Image, $this>
-     */
-    public function image(): MorphOne
-    {
-        return $this->morphOne(Image::class, 'imageable');
-    }
-
-    /**
-     * @return MorphMany<Comment, $this>
-     */
-    public function comments(): MorphMany
-    {
-        return $this->morphMany(Comment::class, 'commentable');
-    }
-
-    /**
-     * @return MorphToMany<Tag, $this>
-     */
-    public function tags(): MorphToMany
-    {
-        return $this->morphToMany(Tag::class, 'taggable');
-    }
-
-    /**
-     * @return HasManyThrough<Deployment, Task, $this>
-     */
-    public function deployments(): HasManyThrough
-    {
-        return $this->hasManyThrough(Deployment::class, Task::class);
-    }
-
-    /**
-     * @return HasOneThrough<Deployment, Task, $this>
-     */
-    public function latestDeployment(): HasOneThrough
-    {
-        return $this->hasOneThrough(Deployment::class, Task::class)->latestOfMany();
+        return $this->hasMany(Review::class);
     }
 
     public function used(Builder $query): void
     {
-        $query->whereHas('tasks');
+        $query->whereHas('reviews');
     }
 
-    protected static function newFactory(): ProjectFactory
+    protected static function newFactory(): ArticleFactory
     {
-        return ProjectFactory::new();
+        return ArticleFactory::new();
     }
 }

--- a/workbench/app/Models/Category.php
+++ b/workbench/app/Models/Category.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/app/Models/Category.php
+++ b/workbench/app/Models/Category.php
@@ -41,8 +41,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
-use Workbench\App\Models\Article;
-use Workbench\App\Models\Review;
 use Workbench\Database\Factories\CategoryFactory;
 
 class Category extends Model

--- a/workbench/app/Models/Category.php
+++ b/workbench/app/Models/Category.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -38,46 +38,45 @@ namespace Workbench\App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+use Workbench\App\Models\Article;
+use Workbench\App\Models\Review;
+use Workbench\Database\Factories\CategoryFactory;
 
-class Task extends Model
+class Category extends Model
 {
     use HasFactory;
 
     protected $guarded = [];
 
     /**
-     * @return BelongsTo<Project, $this>
+     * @return HasMany<Article, $this>
      */
-    public function project(): BelongsTo
+    public function articles(): HasMany
     {
-        return $this->belongsTo(Project::class);
+        return $this->hasMany(Article::class);
     }
 
     /**
-     * @return HasOne<Deployment, $this>
+     * @return HasOneThrough<Review, Article, $this>
      */
-    public function deployment(): HasOne
+    public function latestReview(): HasOneThrough
     {
-        return $this->hasOne(Deployment::class);
+        return $this->hasOneThrough(Review::class, Article::class)->latestOfMany();
     }
 
     /**
-     * @return BelongsToMany<Tag, $this>
+     * @return HasManyThrough<Review, Article, $this>
      */
-    public function tags(): BelongsToMany
+    public function reviews(): HasManyThrough
     {
-        return $this->belongsToMany(Tag::class);
+        return $this->hasManyThrough(Review::class, Article::class);
     }
 
-    protected static function newFactory(): TaskFactory
+    protected static function newFactory(): CategoryFactory
     {
-        return TaskFactory::new();
+        return CategoryFactory::new();
     }
 }

--- a/workbench/app/Models/Comment.php
+++ b/workbench/app/Models/Comment.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/app/Models/Comment.php
+++ b/workbench/app/Models/Comment.php
@@ -39,8 +39,6 @@ namespace Workbench\App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Workbench\App\Models\Project;
-use Workbench\App\Models\Task;
 use Workbench\Database\Factories\CommentFactory;
 
 class Comment extends Model

--- a/workbench/app/Models/Comment.php
+++ b/workbench/app/Models/Comment.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -38,46 +38,27 @@ namespace Workbench\App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
+use Workbench\App\Models\Task;
+use Workbench\Database\Factories\CommentFactory;
 
-class Task extends Model
+class Comment extends Model
 {
     use HasFactory;
 
     protected $guarded = [];
 
     /**
-     * @return BelongsTo<Project, $this>
+     * @return MorphTo<Project|Task, $this>
      */
-    public function project(): BelongsTo
+    public function commentable(): MorphTo
     {
-        return $this->belongsTo(Project::class);
+        return $this->morphTo();
     }
 
-    /**
-     * @return HasOne<Deployment, $this>
-     */
-    public function deployment(): HasOne
+    protected static function newFactory(): CommentFactory
     {
-        return $this->hasOne(Deployment::class);
-    }
-
-    /**
-     * @return BelongsToMany<Tag, $this>
-     */
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class);
-    }
-
-    protected static function newFactory(): TaskFactory
-    {
-        return TaskFactory::new();
+        return CommentFactory::new();
     }
 }

--- a/workbench/app/Models/Deployment.php
+++ b/workbench/app/Models/Deployment.php
@@ -41,7 +41,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Workbench\App\Models\Task;
 use Workbench\Database\Factories\DeploymentFactory;
 
 class Deployment extends Model

--- a/workbench/app/Models/Deployment.php
+++ b/workbench/app/Models/Deployment.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/app/Models/Deployment.php
+++ b/workbench/app/Models/Deployment.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -36,48 +36,36 @@
 
 namespace Workbench\App\Models;
 
+use CanyonGBS\Common\Models\Concerns\CanBeArchived;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
+use Workbench\App\Models\Task;
+use Workbench\Database\Factories\DeploymentFactory;
 
-class Task extends Model
+class Deployment extends Model
 {
+    use CanBeArchived;
     use HasFactory;
 
     protected $guarded = [];
 
     /**
-     * @return BelongsTo<Project, $this>
+     * @return BelongsTo<Task, $this>
      */
-    public function project(): BelongsTo
+    public function task(): BelongsTo
     {
-        return $this->belongsTo(Project::class);
+        return $this->belongsTo(Task::class);
     }
 
-    /**
-     * @return HasOne<Deployment, $this>
-     */
-    public function deployment(): HasOne
+    public function used(Builder $query): void
     {
-        return $this->hasOne(Deployment::class);
+        $query->whereHas('task');
     }
 
-    /**
-     * @return BelongsToMany<Tag, $this>
-     */
-    public function tags(): BelongsToMany
+    protected static function newFactory(): DeploymentFactory
     {
-        return $this->belongsToMany(Tag::class);
-    }
-
-    protected static function newFactory(): TaskFactory
-    {
-        return TaskFactory::new();
+        return DeploymentFactory::new();
     }
 }

--- a/workbench/app/Models/Image.php
+++ b/workbench/app/Models/Image.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -36,48 +36,30 @@
 
 namespace Workbench\App\Models;
 
+use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
+use Workbench\Database\Factories\ImageFactory;
 
-class Task extends Model
+class Image extends Model
 {
+    use CanBeArchived;
     use HasFactory;
 
     protected $guarded = [];
 
     /**
-     * @return BelongsTo<Project, $this>
+     * @return MorphTo<Project|self, $this>
      */
-    public function project(): BelongsTo
+    public function imageable(): MorphTo
     {
-        return $this->belongsTo(Project::class);
+        return $this->morphTo();
     }
 
-    /**
-     * @return HasOne<Deployment, $this>
-     */
-    public function deployment(): HasOne
+    protected static function newFactory(): ImageFactory
     {
-        return $this->hasOne(Deployment::class);
-    }
-
-    /**
-     * @return BelongsToMany<Tag, $this>
-     */
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class);
-    }
-
-    protected static function newFactory(): TaskFactory
-    {
-        return TaskFactory::new();
+        return ImageFactory::new();
     }
 }

--- a/workbench/app/Models/Image.php
+++ b/workbench/app/Models/Image.php
@@ -40,7 +40,6 @@ use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Workbench\App\Models\Project;
 use Workbench\Database\Factories\ImageFactory;
 
 class Image extends Model

--- a/workbench/app/Models/Image.php
+++ b/workbench/app/Models/Image.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/app/Models/Project.php
+++ b/workbench/app/Models/Project.php
@@ -47,11 +47,6 @@ use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Workbench\App\Models\Comment;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Image;
-use Workbench\App\Models\Tag;
-use Workbench\App\Models\Task;
 use Workbench\Database\Factories\ProjectFactory;
 
 class Project extends Model

--- a/workbench/app/Models/Project.php
+++ b/workbench/app/Models/Project.php
@@ -41,6 +41,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Workbench\App\Models\Task;
 use Workbench\Database\Factories\ProjectFactory;
 
 class Project extends Model
@@ -50,6 +51,9 @@ class Project extends Model
 
     protected $guarded = [];
 
+    /**
+     * @return HasMany<Task, $this>
+     */
     public function tasks(): HasMany
     {
         return $this->hasMany(Task::class);

--- a/workbench/app/Models/Project.php
+++ b/workbench/app/Models/Project.php
@@ -41,7 +41,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Workbench\App\Models\Task;
 use Workbench\Database\Factories\ProjectFactory;
 
 class Project extends Model

--- a/workbench/app/Models/Review.php
+++ b/workbench/app/Models/Review.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/app/Models/Review.php
+++ b/workbench/app/Models/Review.php
@@ -39,7 +39,6 @@ namespace Workbench\App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Workbench\App\Models\Article;
 use Workbench\Database\Factories\ReviewFactory;
 
 class Review extends Model

--- a/workbench/app/Models/Review.php
+++ b/workbench/app/Models/Review.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -39,45 +39,25 @@ namespace Workbench\App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
+use Workbench\App\Models\Article;
+use Workbench\Database\Factories\ReviewFactory;
 
-class Task extends Model
+class Review extends Model
 {
     use HasFactory;
 
     protected $guarded = [];
 
     /**
-     * @return BelongsTo<Project, $this>
+     * @return BelongsTo<Article, $this>
      */
-    public function project(): BelongsTo
+    public function article(): BelongsTo
     {
-        return $this->belongsTo(Project::class);
+        return $this->belongsTo(Article::class);
     }
 
-    /**
-     * @return HasOne<Deployment, $this>
-     */
-    public function deployment(): HasOne
+    protected static function newFactory(): ReviewFactory
     {
-        return $this->hasOne(Deployment::class);
-    }
-
-    /**
-     * @return BelongsToMany<Tag, $this>
-     */
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class);
-    }
-
-    protected static function newFactory(): TaskFactory
-    {
-        return TaskFactory::new();
+        return ReviewFactory::new();
     }
 }

--- a/workbench/app/Models/Tag.php
+++ b/workbench/app/Models/Tag.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -40,21 +40,17 @@ use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasManyThrough;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Workbench\App\Models\Comment;
-use Workbench\App\Models\Deployment;
 use Workbench\App\Models\Image;
-use Workbench\App\Models\Tag;
+use Workbench\App\Models\Review;
 use Workbench\App\Models\Task;
-use Workbench\Database\Factories\ProjectFactory;
+use Workbench\Database\Factories\TagFactory;
 
-class Project extends Model
+class Tag extends Model
 {
     use CanBeArchived;
     use HasFactory;
@@ -62,59 +58,35 @@ class Project extends Model
     protected $guarded = [];
 
     /**
-     * @return HasMany<Task, $this>
+     * @return BelongsToMany<Task, $this>
      */
-    public function tasks(): HasMany
+    public function tasks(): BelongsToMany
     {
-        return $this->hasMany(Task::class);
+        return $this->belongsToMany(Task::class);
     }
 
     /**
-     * @return HasOne<Task, $this>
+     * @return MorphOne<Comment, $this>
      */
-    public function latestTask(): HasOne
+    public function comment(): MorphOne
     {
-        return $this->hasOne(Task::class)->latestOfMany();
+        return $this->morphOne(Comment::class, 'commentable');
     }
 
     /**
-     * @return MorphOne<Image, $this>
+     * @return MorphMany<Image, $this>
      */
-    public function image(): MorphOne
+    public function images(): MorphMany
     {
-        return $this->morphOne(Image::class, 'imageable');
+        return $this->morphMany(Image::class, 'imageable');
     }
 
     /**
-     * @return MorphMany<Comment, $this>
+     * @return MorphToMany<Review, $this>
      */
-    public function comments(): MorphMany
+    public function reviews(): MorphToMany
     {
-        return $this->morphMany(Comment::class, 'commentable');
-    }
-
-    /**
-     * @return MorphToMany<Tag, $this>
-     */
-    public function tags(): MorphToMany
-    {
-        return $this->morphToMany(Tag::class, 'taggable');
-    }
-
-    /**
-     * @return HasManyThrough<Deployment, Task, $this>
-     */
-    public function deployments(): HasManyThrough
-    {
-        return $this->hasManyThrough(Deployment::class, Task::class);
-    }
-
-    /**
-     * @return HasOneThrough<Deployment, Task, $this>
-     */
-    public function latestDeployment(): HasOneThrough
-    {
-        return $this->hasOneThrough(Deployment::class, Task::class)->latestOfMany();
+        return $this->morphedByMany(Review::class, 'taggable');
     }
 
     public function used(Builder $query): void
@@ -122,8 +94,8 @@ class Project extends Model
         $query->whereHas('tasks');
     }
 
-    protected static function newFactory(): ProjectFactory
+    protected static function newFactory(): TagFactory
     {
-        return ProjectFactory::new();
+        return TagFactory::new();
     }
 }

--- a/workbench/app/Models/Tag.php
+++ b/workbench/app/Models/Tag.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/app/Models/Tag.php
+++ b/workbench/app/Models/Tag.php
@@ -44,10 +44,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Workbench\App\Models\Comment;
-use Workbench\App\Models\Image;
-use Workbench\App\Models\Review;
-use Workbench\App\Models\Task;
 use Workbench\Database\Factories\TagFactory;
 
 class Tag extends Model

--- a/workbench/app/Models/Task.php
+++ b/workbench/app/Models/Task.php
@@ -41,9 +41,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
 use Workbench\Database\Factories\TaskFactory;
 
 class Task extends Model

--- a/workbench/app/Models/Task.php
+++ b/workbench/app/Models/Task.php
@@ -39,7 +39,6 @@ namespace Workbench\App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Workbench\App\Models\Project;
 use Workbench\Database\Factories\TaskFactory;
 
 class Task extends Model

--- a/workbench/app/Models/Task.php
+++ b/workbench/app/Models/Task.php
@@ -39,6 +39,7 @@ namespace Workbench\App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workbench\App\Models\Project;
 use Workbench\Database\Factories\TaskFactory;
 
 class Task extends Model
@@ -47,6 +48,9 @@ class Task extends Model
 
     protected $guarded = [];
 
+    /**
+     * @return BelongsTo<Project, $this>
+     */
     public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class);

--- a/workbench/database/factories/ArticleFactory.php
+++ b/workbench/database/factories/ArticleFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -34,50 +34,22 @@
 </COPYRIGHT>
 */
 
-namespace Workbench\App\Models;
+namespace Workbench\Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Article;
 
-class Task extends Model
+/** @extends Factory<Article> */
+class ArticleFactory extends Factory
 {
-    use HasFactory;
+    protected $model = Article::class;
 
-    protected $guarded = [];
-
-    /**
-     * @return BelongsTo<Project, $this>
-     */
-    public function project(): BelongsTo
+    /** @return array<string, mixed> */
+    public function definition(): array
     {
-        return $this->belongsTo(Project::class);
-    }
-
-    /**
-     * @return HasOne<Deployment, $this>
-     */
-    public function deployment(): HasOne
-    {
-        return $this->hasOne(Deployment::class);
-    }
-
-    /**
-     * @return BelongsToMany<Tag, $this>
-     */
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class);
-    }
-
-    protected static function newFactory(): TaskFactory
-    {
-        return TaskFactory::new();
+        return [
+            'category_id' => CategoryFactory::new(),
+            'name' => fake()->sentence(),
+        ];
     }
 }

--- a/workbench/database/factories/ArticleFactory.php
+++ b/workbench/database/factories/ArticleFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/database/factories/CategoryFactory.php
+++ b/workbench/database/factories/CategoryFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -34,50 +34,21 @@
 </COPYRIGHT>
 */
 
-namespace Workbench\App\Models;
+namespace Workbench\Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Category;
 
-class Task extends Model
+/** @extends Factory<Category> */
+class CategoryFactory extends Factory
 {
-    use HasFactory;
+    protected $model = Category::class;
 
-    protected $guarded = [];
-
-    /**
-     * @return BelongsTo<Project, $this>
-     */
-    public function project(): BelongsTo
+    /** @return array<string, mixed> */
+    public function definition(): array
     {
-        return $this->belongsTo(Project::class);
-    }
-
-    /**
-     * @return HasOne<Deployment, $this>
-     */
-    public function deployment(): HasOne
-    {
-        return $this->hasOne(Deployment::class);
-    }
-
-    /**
-     * @return BelongsToMany<Tag, $this>
-     */
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class);
-    }
-
-    protected static function newFactory(): TaskFactory
-    {
-        return TaskFactory::new();
+        return [
+            'name' => fake()->word(),
+        ];
     }
 }

--- a/workbench/database/factories/CategoryFactory.php
+++ b/workbench/database/factories/CategoryFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/database/factories/CommentFactory.php
+++ b/workbench/database/factories/CommentFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -34,50 +34,23 @@
 </COPYRIGHT>
 */
 
-namespace Workbench\App\Models;
+namespace Workbench\Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Comment;
 
-class Task extends Model
+/** @extends Factory<Comment> */
+class CommentFactory extends Factory
 {
-    use HasFactory;
+    protected $model = Comment::class;
 
-    protected $guarded = [];
-
-    /**
-     * @return BelongsTo<Project, $this>
-     */
-    public function project(): BelongsTo
+    /** @return array<string, mixed> */
+    public function definition(): array
     {
-        return $this->belongsTo(Project::class);
-    }
-
-    /**
-     * @return HasOne<Deployment, $this>
-     */
-    public function deployment(): HasOne
-    {
-        return $this->hasOne(Deployment::class);
-    }
-
-    /**
-     * @return BelongsToMany<Tag, $this>
-     */
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class);
-    }
-
-    protected static function newFactory(): TaskFactory
-    {
-        return TaskFactory::new();
+        return [
+            'body' => fake()->paragraph(),
+            'commentable_id' => ProjectFactory::new(),
+            'commentable_type' => 'Workbench\App\Models\Project',
+        ];
     }
 }

--- a/workbench/database/factories/CommentFactory.php
+++ b/workbench/database/factories/CommentFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/database/factories/DeploymentFactory.php
+++ b/workbench/database/factories/DeploymentFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -34,50 +34,22 @@
 </COPYRIGHT>
 */
 
-namespace Workbench\App\Models;
+namespace Workbench\Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
 
-class Task extends Model
+/** @extends Factory<Deployment> */
+class DeploymentFactory extends Factory
 {
-    use HasFactory;
+    protected $model = Deployment::class;
 
-    protected $guarded = [];
-
-    /**
-     * @return BelongsTo<Project, $this>
-     */
-    public function project(): BelongsTo
+    /** @return array<string, mixed> */
+    public function definition(): array
     {
-        return $this->belongsTo(Project::class);
-    }
-
-    /**
-     * @return HasOne<Deployment, $this>
-     */
-    public function deployment(): HasOne
-    {
-        return $this->hasOne(Deployment::class);
-    }
-
-    /**
-     * @return BelongsToMany<Tag, $this>
-     */
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class);
-    }
-
-    protected static function newFactory(): TaskFactory
-    {
-        return TaskFactory::new();
+        return [
+            'task_id' => TaskFactory::new(),
+            'commit_hash' => fake()->sha1(),
+        ];
     }
 }

--- a/workbench/database/factories/DeploymentFactory.php
+++ b/workbench/database/factories/DeploymentFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/database/factories/ImageFactory.php
+++ b/workbench/database/factories/ImageFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -34,50 +34,23 @@
 </COPYRIGHT>
 */
 
-namespace Workbench\App\Models;
+namespace Workbench\Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Image;
 
-class Task extends Model
+/** @extends Factory<Image> */
+class ImageFactory extends Factory
 {
-    use HasFactory;
+    protected $model = Image::class;
 
-    protected $guarded = [];
-
-    /**
-     * @return BelongsTo<Project, $this>
-     */
-    public function project(): BelongsTo
+    /** @return array<string, mixed> */
+    public function definition(): array
     {
-        return $this->belongsTo(Project::class);
-    }
-
-    /**
-     * @return HasOne<Deployment, $this>
-     */
-    public function deployment(): HasOne
-    {
-        return $this->hasOne(Deployment::class);
-    }
-
-    /**
-     * @return BelongsToMany<Tag, $this>
-     */
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class);
-    }
-
-    protected static function newFactory(): TaskFactory
-    {
-        return TaskFactory::new();
+        return [
+            'url' => fake()->url(),
+            'imageable_id' => ProjectFactory::new(),
+            'imageable_type' => 'Workbench\App\Models\Project',
+        ];
     }
 }

--- a/workbench/database/factories/ImageFactory.php
+++ b/workbench/database/factories/ImageFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/database/factories/ReviewFactory.php
+++ b/workbench/database/factories/ReviewFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/database/factories/ReviewFactory.php
+++ b/workbench/database/factories/ReviewFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -34,50 +34,22 @@
 </COPYRIGHT>
 */
 
-namespace Workbench\App\Models;
+namespace Workbench\Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Project;
-use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Review;
 
-class Task extends Model
+/** @extends Factory<Review> */
+class ReviewFactory extends Factory
 {
-    use HasFactory;
+    protected $model = Review::class;
 
-    protected $guarded = [];
-
-    /**
-     * @return BelongsTo<Project, $this>
-     */
-    public function project(): BelongsTo
+    /** @return array<string, mixed> */
+    public function definition(): array
     {
-        return $this->belongsTo(Project::class);
-    }
-
-    /**
-     * @return HasOne<Deployment, $this>
-     */
-    public function deployment(): HasOne
-    {
-        return $this->hasOne(Deployment::class);
-    }
-
-    /**
-     * @return BelongsToMany<Tag, $this>
-     */
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class);
-    }
-
-    protected static function newFactory(): TaskFactory
-    {
-        return TaskFactory::new();
+        return [
+            'article_id' => ArticleFactory::new(),
+            'body' => fake()->paragraph(),
+        ];
     }
 }

--- a/workbench/database/factories/TagFactory.php
+++ b/workbench/database/factories/TagFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/workbench/database/factories/TagFactory.php
+++ b/workbench/database/factories/TagFactory.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -34,50 +34,21 @@
 </COPYRIGHT>
 */
 
-namespace Workbench\App\Models;
+namespace Workbench\Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Workbench\App\Models\Deployment;
-use Workbench\App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Workbench\App\Models\Tag;
-use Workbench\Database\Factories\TaskFactory;
 
-class Task extends Model
+/** @extends Factory<Tag> */
+class TagFactory extends Factory
 {
-    use HasFactory;
+    protected $model = Tag::class;
 
-    protected $guarded = [];
-
-    /**
-     * @return BelongsTo<Project, $this>
-     */
-    public function project(): BelongsTo
+    /** @return array<string, mixed> */
+    public function definition(): array
     {
-        return $this->belongsTo(Project::class);
-    }
-
-    /**
-     * @return HasOne<Deployment, $this>
-     */
-    public function deployment(): HasOne
-    {
-        return $this->hasOne(Deployment::class);
-    }
-
-    /**
-     * @return BelongsToMany<Tag, $this>
-     */
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class);
-    }
-
-    protected static function newFactory(): TaskFactory
-    {
-        return TaskFactory::new();
+        return [
+            'name' => fake()->word(),
+        ];
     }
 }

--- a/workbench/database/migrations/0001_01_01_000001_create_test_tables.php
+++ b/workbench/database/migrations/0001_01_01_000001_create_test_tables.php
@@ -54,10 +54,81 @@ return new class () extends Migration {
             $table->string('name');
             $table->timestamps();
         });
+
+        Schema::create('images', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('imageable');
+            $table->string('url');
+            $table->timestamp('archived_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('commentable');
+            $table->text('body');
+            $table->timestamps();
+        });
+
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamp('archived_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('tag_task', function (Blueprint $table) {
+            $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('task_id')->constrained()->cascadeOnDelete();
+            $table->primary(['tag_id', 'task_id']);
+        });
+
+        Schema::create('taggables', function (Blueprint $table) {
+            $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
+            $table->morphs('taggable');
+        });
+
+        Schema::create('deployments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('task_id')->constrained()->cascadeOnDelete();
+            $table->string('commit_hash');
+            $table->timestamp('archived_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->timestamp('archived_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('reviews', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('article_id')->constrained()->cascadeOnDelete();
+            $table->text('body');
+            $table->timestamps();
+        });
     }
 
     public function down(): void
     {
+        Schema::dropIfExists('reviews');
+        Schema::dropIfExists('articles');
+        Schema::dropIfExists('categories');
+        Schema::dropIfExists('deployments');
+        Schema::dropIfExists('taggables');
+        Schema::dropIfExists('tag_task');
+        Schema::dropIfExists('tags');
+        Schema::dropIfExists('comments');
+        Schema::dropIfExists('images');
         Schema::dropIfExists('tasks');
         Schema::dropIfExists('projects');
     }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

This creates a custom PHPStan extension to allow for the usage of the archive methods added via the `CanBeArchived` methods that it previously could not resolve. IF it can trace the model / builder to a model using `CanBeArchived`.

### Any deployment steps required?

This will need to be released, the other projects updated to that release, and then they will need to add `commons` `phpstan-extension.neon` to their PHPStan config includes.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/common/blob/main/README.md#contributing).
