### PR TITLE
Change to VoidType to prevent PHPStan false positive on whereHas-esk returns

### DIFF
--- a/src/Support/PHPStan/WhereHasClosureTypeExtension.php
+++ b/src/Support/PHPStan/WhereHasClosureTypeExtension.php
@@ -60,9 +60,9 @@ use PHPStan\Type\ClosureType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateObjectType;
 use PHPStan\Type\MethodParameterClosureTypeExtension;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\VoidType;
 
 use function str_contains;
 
@@ -157,7 +157,7 @@ class WhereHasClosureTypeExtension implements MethodParameterClosureTypeExtensio
                     null,
                 ),
             ],
-            new MixedType(),
+            new VoidType(),
         );
     }
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Update the `whereHas`-esk extension for archive methods/scopes to return `VoidType` to prevent false-positive PHPStan flags.

Since these returns don't care what get's returned it is just throwing non-covariant errors in PHPStan that are not needed.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/common/blob/main/README.md#contributing).
