### PR TITLE
[OLYMPUS-1208]: Add permission migration make command

### DIFF
--- a/src/CommonServiceProvider.php
+++ b/src/CommonServiceProvider.php
@@ -36,9 +36,11 @@
 
 namespace CanyonGBS\Common;
 
+use CanyonGBS\Common\Console\Commands\CreatePermissionMigration;
 use CanyonGBS\Common\Console\Commands\MakeCleanupTask;
 use CanyonGBS\Common\Console\Commands\MakeFeatureFlag;
 use CanyonGBS\Common\Console\Commands\MakeTmpMigration;
+use CanyonGBS\Common\Database\Migrations\PermissionMigrationCreator;
 use Filament\Support\Assets\Js;
 use Filament\Support\Colors\Color;
 use Filament\Support\Facades\FilamentAsset;
@@ -68,7 +70,18 @@ class CommonServiceProvider extends PackageServiceProvider
             return new MakeTmpMigration($app['migration.creator'], $app[Composer::class]);
         });
 
-        $this->commands([MakeTmpMigration::class]);
+        $this->app->singleton(PermissionMigrationCreator::class, function (Application $app) {
+            return new PermissionMigrationCreator($app['files'], $app->basePath('stubs'));
+        });
+
+        $this->app->singleton(CreatePermissionMigration::class, function (Application $app) {
+            return new CreatePermissionMigration($app[PermissionMigrationCreator::class], $app[Composer::class]);
+        });
+
+        $this->commands([
+            MakeTmpMigration::class,
+            CreatePermissionMigration::class,
+        ]);
     }
 
     public function packageBooted(): void

--- a/src/Console/Commands/CreatePermissionMigration.php
+++ b/src/Console/Commands/CreatePermissionMigration.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Console\Commands;
+
+use CanyonGBS\Common\Database\Migrations\PermissionMigrationCreator;
+use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Composer;
+use InterNACHI\Modularize\ModularizeGeneratorCommand;
+
+class CreatePermissionMigration extends MigrateMakeCommand
+{
+    use ModularizeGeneratorCommand;
+
+    protected $signature = 'make:permission-migration {name : The name of the migration}
+        {--create= : The table to be created}
+        {--table= : The table to migrate}
+        {--path= : The location where the migration file should be created}
+        {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
+        {--fullpath : Output the full path of the migration (Deprecated)}';
+
+    protected $description = 'Creates a permission migration file.';
+
+    public function __construct(PermissionMigrationCreator $creator, Composer $composer)
+    {
+        parent::__construct($creator, $composer);
+    }
+
+    protected function getMigrationPath()
+    {
+        $path = parent::getMigrationPath();
+
+        if ($module = $this->module()) {
+            $appDirectory = $this->laravel->databasePath('migrations');
+            $moduleDirectory = $module->path('database/migrations');
+
+            $path = str_replace($appDirectory, $moduleDirectory, $path);
+
+            $filesystem = $this->laravel->make(Filesystem::class);
+
+            if (! $filesystem->isDirectory($moduleDirectory)) {
+                $filesystem->makeDirectory($moduleDirectory, 0755, true);
+            }
+        }
+
+        return $path;
+    }
+}

--- a/src/Database/Migrations/PermissionMigrationCreator.php
+++ b/src/Database/Migrations/PermissionMigrationCreator.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Database\Migrations;
+
+use Illuminate\Database\Migrations\MigrationCreator;
+
+class PermissionMigrationCreator extends MigrationCreator
+{
+    protected function getStub($table, $create)
+    {
+        return $this->files->get(
+            $this->files->exists($customPath = $this->customStubPath . '/permission-migration.stub')
+                ? $customPath
+                : __DIR__ . '/../../../stubs/permission-migration.stub'
+        );
+    }
+}

--- a/stubs/permission-migration.stub
+++ b/stubs/permission-migration.stub
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use CanyonGBS\Common\Database\Migrations\Concerns\CanModifyPermissions;
+
+return new class extends Migration
+{
+    use CanModifyPermissions;
+
+    private array $permissions = [
+        'permission-name.view-any' => 'Permission Group',
+        'permission-name.create' => 'Permission Group',
+        'permission-name.*.view' => 'Permission Group',
+        'permission-name.*.update' => 'Permission Group',
+        'permission-name.*.delete' => 'Permission Group',
+        'permission-name.*.restore' => 'Permission Group',
+        'permission-name.*.force-delete' => 'Permission Group',
+        // 'permission-name.import' => 'Permission Group', // Add only if needed / requested
+    ];
+
+    // Replace with this app's guard(s) — e.g. ['staff_web'] or ['web', 'api'].
+    // Each app should override this stub via its own stubs/permission-migration.stub.
+    private array $guards = [
+        'guard-name',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->guards as $guard) {
+            $this->createPermissions($this->permissions, $guard);
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->guards as $guard) {
+            $this->deletePermissions(array_keys($this->permissions), $guard);
+        }
+    }
+};

--- a/tests/Console/CreatePermissionMigrationTest.php
+++ b/tests/Console/CreatePermissionMigrationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use CanyonGBS\Common\Console\Commands\CreatePermissionMigration;
+use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
+use Illuminate\Database\Migrations\MigrationCreator;
+use Illuminate\Support\Facades\File;
+
+beforeEach(function () {
+    $this->testDir = sys_get_temp_dir() . '/' . uniqid('common-permission-migration-test-');
+    mkdir($this->testDir, 0755, true);
+    $this->app->setBasePath($this->testDir);
+    $this->migrationsDir = $this->app->databasePath('migrations');
+});
+
+afterEach(function () {
+    File::deleteDirectory($this->testDir);
+});
+
+it('creates a permission migration file in database/migrations', function () {
+    $this->artisan('make:permission-migration', ['name' => 'seed_permissions_for_example'])
+        ->assertSuccessful();
+
+    $files = glob($this->migrationsDir . '/*_seed_permissions_for_example.php');
+
+    expect($files)->toHaveCount(1);
+});
+
+it('falls back to the bundled placeholder stub when the app provides none', function () {
+    $this->artisan('make:permission-migration', ['name' => 'seed_permissions_for_fallback'])
+        ->assertSuccessful();
+
+    $files = glob($this->migrationsDir . '/*_seed_permissions_for_fallback.php');
+
+    expect($files)->toHaveCount(1);
+
+    $content = file_get_contents($files[0]);
+
+    // The bundled fallback uses the CanModifyPermissions trait and a placeholder guard,
+    // never a real guard, so a missing-stub app can't silently generate wrong guards.
+    expect($content)->toContain('use CanModifyPermissions;')
+        ->and($content)->toContain('createPermissions')
+        ->and($content)->toContain('guard-name');
+});
+
+it('honors an app-level stubs/permission-migration.stub override', function () {
+    // Discover where the creator actually looks for an app-level stub (its
+    // customStubPath, captured when the command was constructed) and write the
+    // override there. This keeps the test independent of base-path resolution
+    // timing — in a real app the base path is fixed at bootstrap, long before any
+    // command resolves, so the override is always read from <base>/stubs.
+    $command = $this->app->make(CreatePermissionMigration::class);
+    $creator = Closure::bind(fn () => $this->creator, $command, MigrateMakeCommand::class)();
+    $stubsDir = Closure::bind(fn () => $this->customStubPath, $creator, MigrationCreator::class)();
+
+    File::ensureDirectoryExists($stubsDir);
+    $stubFile = $stubsDir . '/permission-migration.stub';
+    file_put_contents($stubFile, "<?php\n\n// APP OVERRIDE staff_web\n");
+
+    try {
+        $this->artisan('make:permission-migration', ['name' => 'seed_permissions_for_override'])
+            ->assertSuccessful();
+
+        $files = glob($this->migrationsDir . '/*_seed_permissions_for_override.php');
+
+        expect($files)->toHaveCount(1);
+
+        $content = file_get_contents($files[0]);
+
+        expect($content)->toContain('APP OVERRIDE staff_web');
+    } finally {
+        @unlink($stubFile);
+    }
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/OLYMPUS-1208

### Technical Description

> Adds a shared `make:permission-migration` artisan command to common. Today advising and aiding each maintain their own copy of this command + a `PermissionMigrationCreator` override + a stub. This centralizes the command and creator so all apps consume one implementation.

> Guards differ per app (advising/aiding: `web`+`api`, olympus: `staff_web`). The creator resolves the stub from the **consuming app's** `stubs/permission-migration.stub` first (via `basePath('stubs')`, evaluated at runtime), so each app keeps its own guards. Common only ships a **fallback** stub, and that fallback uses a placeholder guard (`guard-name`) - never a real one - so an app that forgets its stub can't silently produce the wrong guard.


### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/common/blob/main/README.md#contributing).
