### PR TITLE
[Chore]: Add various team approved and designed Rector and PHPStan rules

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ resources/views/mail/**/*.blade.php
 resources/lang/**/*.php
 resources/js/dist/**
 **/vendor/
+**/*.php.inc

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "pestphp/pest-plugin-laravel": "^3.2",
         "friendsofphp/php-cs-fixer": "^3.75",
         "orrison/meliorstan": "^0.3.2",
-        "larastan/larastan": "^3.0"
+        "larastan/larastan": "^3.0",
+        "rector/rector": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -59,11 +60,19 @@
         "clear-prettier-cache": [
             "rm -f ./node_modules/.cache/prettier/.prettier-cache"
         ],
+        "rector": [
+            "./vendor/bin/rector process"
+        ],
+        "rector-dryrun": [
+            "./vendor/bin/rector process --dry-run"
+        ],
         "format-dryrun": [
+            "@rector-dryrun",
             "@php-cs-format-dryrun",
             "@prettier-format-dryrun"
         ],
         "format": [
+            "@rector",
             "@php-cs-format",
             "@prettier-format"
         ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d4e38f723fb44538d60aa888476cc53",
+    "content-hash": "b955f8b5cec86ed23ca015fa283897b5",
     "packages": [
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -13512,6 +13512,66 @@
                 }
             ],
             "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "49ff6339174bdbdf50b0b35ecbcff14a05ac9e24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/49ff6339174bdbdf50b0b35ecbcff14a05ac9e24",
+                "reference": "49ff6339174bdbdf50b0b35ecbcff14a05ac9e24",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.2.2"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-22T11:39:33+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -16,6 +16,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: CanyonGBS\Common\Rules\MigrationHasUpAndDownMethods\MigrationHasUpAndDownMethodsRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: CanyonGBS\Common\Rules\NoBlueprintAfterGrouping\NoBlueprintAfterGroupingRule
         tags:
             - phpstan.rules.rule

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -19,3 +19,7 @@ services:
         class: CanyonGBS\Common\Rules\NoBlueprintAfterGrouping\NoBlueprintAfterGroupingRule
         tags:
             - phpstan.rules.rule
+    -
+        class: CanyonGBS\Common\Rules\NoJsonColumnInMigration\NoJsonColumnInMigrationRule
+        tags:
+            - phpstan.rules.rule

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -15,3 +15,7 @@ services:
         class: CanyonGBS\Common\Rules\DeleteForceDeleteRestoreBulkEquivalents\DeleteForceDeleteRestoreBulkEquivalentsRule
         tags:
             - phpstan.rules.rule
+    -
+        class: CanyonGBS\Common\Rules\NoBlueprintAfterGrouping\NoBlueprintAfterGroupingRule
+        tags:
+            - phpstan.rules.rule

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use CanyonGBS\Common\Rector\CommonSetList;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+        __DIR__ . '/workbench',
+    ])
+    ->withSkip([
+        __DIR__ . '/tests/Rector/*/Fixtures',
+    ])
+    ->withSets([
+        CommonSetList::COMMON,
+    ]);

--- a/rector/sets/common.php
+++ b/rector/sets/common.php
@@ -36,9 +36,11 @@
 
 use CanyonGBS\Common\Rector\FlattenAfterColumnGroupingRector;
 use CanyonGBS\Common\Rector\RemoveAfterColumnModifierRector;
+use CanyonGBS\Common\Rector\UseFakerPropertyInFactoryRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(RemoveAfterColumnModifierRector::class);
     $rectorConfig->rule(FlattenAfterColumnGroupingRector::class);
+    $rectorConfig->rule(UseFakerPropertyInFactoryRector::class);
 };

--- a/rector/sets/common.php
+++ b/rector/sets/common.php
@@ -34,9 +34,11 @@
 </COPYRIGHT>
 */
 
+use CanyonGBS\Common\Rector\FlattenAfterColumnGroupingRector;
 use CanyonGBS\Common\Rector\RemoveAfterColumnModifierRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(RemoveAfterColumnModifierRector::class);
+    $rectorConfig->rule(FlattenAfterColumnGroupingRector::class);
 };

--- a/rector/sets/common.php
+++ b/rector/sets/common.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use CanyonGBS\Common\Rector\RemoveAfterColumnModifierRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveAfterColumnModifierRector::class);
+};

--- a/src/Rector/CommonSetList.php
+++ b/src/Rector/CommonSetList.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rector;
+
+final class CommonSetList
+{
+    /**
+     * The complete set of Rector rules shared across Canyon GBS applications.
+     *
+     * Register this set in a consuming application's "rector.php" to opt into
+     * every rule defined by this package. New rules added in future releases
+     * are pulled in automatically when the package is updated.
+     */
+    public const string COMMON = __DIR__ . '/../../rector/sets/common.php';
+}

--- a/src/Rector/FlattenAfterColumnGroupingRector.php
+++ b/src/Rector/FlattenAfterColumnGroupingRector.php
@@ -1,0 +1,185 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Expression;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class FlattenAfterColumnGroupingRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Flatten the Blueprint "->after()" column grouping in schema migrations by hoisting the grouped column definitions out of the closure, as PostgreSQL does not support positioning columns.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                        Schema::table('users', function (Blueprint $table) {
+                            $table->after('first_name', function (Blueprint $table) {
+                                $table->string('middle_name');
+                                $table->string('suffix');
+                            });
+                        });
+                        CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                        Schema::table('users', function (Blueprint $table) {
+                            $table->string('middle_name');
+                            $table->string('suffix');
+                        });
+                        CODE_SAMPLE,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Expression::class];
+    }
+
+    /**
+     * @param Expression $node
+     *
+     * @return array<Node\Stmt>|null
+     */
+    public function refactor(Node $node): ?array
+    {
+        $methodCall = $node->expr;
+
+        if (! $methodCall instanceof MethodCall) {
+            return null;
+        }
+
+        if (! $this->isName($methodCall->name, 'after')) {
+            return null;
+        }
+
+        if (! $this->isObjectType($methodCall->var, new ObjectType('Illuminate\Database\Schema\Blueprint'))) {
+            return null;
+        }
+
+        // The receiver must be a plain variable so the grouped columns can be hoisted
+        // and the inner closure's Blueprint parameter aligned to it. Anything else is
+        // left for the NoBlueprintAfterGroupingRule PHPStan rule to flag.
+        if (! $methodCall->var instanceof Variable || ! is_string($methodCall->var->name)) {
+            return null;
+        }
+
+        $arguments = $methodCall->getArgs();
+
+        if (count($arguments) < 2) {
+            return null;
+        }
+
+        $callback = $arguments[1]->value;
+
+        if ($callback instanceof Closure) {
+            $statements = $callback->stmts;
+        } elseif ($callback instanceof ArrowFunction) {
+            $statements = [new Expression($callback->expr)];
+        } else {
+            return null;
+        }
+
+        if (count($callback->params) < 1) {
+            return null;
+        }
+
+        $innerParameter = $callback->params[0]->var;
+
+        if (! $innerParameter instanceof Variable || ! is_string($innerParameter->name)) {
+            return null;
+        }
+
+        $outerName = $methodCall->var->name;
+        $innerName = $innerParameter->name;
+
+        if ($innerName !== $outerName) {
+            // Renaming would merge two distinct variables; leave it for PHPStan to flag.
+            if ($this->bodyUsesVariableNamed($statements, $outerName)) {
+                return null;
+            }
+
+            $this->renameVariable($statements, $innerName, $outerName);
+        }
+
+        return $statements;
+    }
+
+    /**
+     * @param array<Node\Stmt> $statements
+     */
+    private function bodyUsesVariableNamed(array $statements, string $name): bool
+    {
+        $found = false;
+
+        $this->traverseNodesWithCallable($statements, function (Node $node) use ($name, &$found): null {
+            if ($node instanceof Variable && is_string($node->name) && $node->name === $name) {
+                $found = true;
+            }
+
+            return null;
+        });
+
+        return $found;
+    }
+
+    /**
+     * @param array<Node\Stmt> $statements
+     */
+    private function renameVariable(array $statements, string $from, string $to): void
+    {
+        $this->traverseNodesWithCallable($statements, function (Node $node) use ($from, $to): null {
+            if ($node instanceof Variable && is_string($node->name) && $node->name === $from) {
+                $node->name = $to;
+            }
+
+            return null;
+        });
+    }
+}

--- a/src/Rector/RemoveAfterColumnModifierRector.php
+++ b/src/Rector/RemoveAfterColumnModifierRector.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class RemoveAfterColumnModifierRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove the "->after()" column modifier from schema migrations, as PostgreSQL does not support positioning columns.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                        Schema::table('users', function (Blueprint $table) {
+                            $table->string('middle_name')->after('first_name');
+                        });
+                        CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                        Schema::table('users', function (Blueprint $table) {
+                            $table->string('middle_name');
+                        });
+                        CODE_SAMPLE,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node->name, 'after')) {
+            return null;
+        }
+
+        if (! $this->isObjectType($node->var, new ObjectType('Illuminate\Database\Schema\ColumnDefinition'))) {
+            return null;
+        }
+
+        return $node->var;
+    }
+}

--- a/src/Rector/UseFakerPropertyInFactoryRector.php
+++ b/src/Rector/UseFakerPropertyInFactoryRector.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class UseFakerPropertyInFactoryRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace the "fake()" helper with "$this->faker" inside Eloquent factories.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                        class UserFactory extends Factory
+                        {
+                            public function definition(): array
+                            {
+                                return [
+                                    'name' => fake()->name(),
+                                ];
+                            }
+                        }
+                        CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                        class UserFactory extends Factory
+                        {
+                            public function definition(): array
+                            {
+                                return [
+                                    'name' => $this->faker->name(),
+                                ];
+                            }
+                        }
+                        CODE_SAMPLE,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?PropertyFetch
+    {
+        if (! $this->isName($node, 'fake')) {
+            return null;
+        }
+
+        // Skip "fake()" calls that pass a locale (or any argument), as "$this->faker"
+        // cannot carry that argument and rewriting would silently drop it.
+        if ($node->getArgs() !== []) {
+            return null;
+        }
+
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
+
+        if (! $scope instanceof Scope) {
+            return null;
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        if (! $classReflection->isSubclassOf('Illuminate\Database\Eloquent\Factories\Factory')) {
+            return null;
+        }
+
+        return new PropertyFetch(new Variable('this'), 'faker');
+    }
+}

--- a/src/Rules/MigrationHasUpAndDownMethods/MigrationHasUpAndDownMethodsRule.php
+++ b/src/Rules/MigrationHasUpAndDownMethods/MigrationHasUpAndDownMethodsRule.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\MigrationHasUpAndDownMethods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Ensures every migration (a subclass of Illuminate\Database\Migrations\Migration)
+ * defines both an "up()" and a "down()" method directly on the class, even when the
+ * method bodies are empty. This keeps migrations reversible and consistent.
+ *
+ * @implements Rule<InClassNode>
+ */
+class MigrationHasUpAndDownMethodsRule implements Rule
+{
+    public const string MIGRATION_CLASS = 'Illuminate\Database\Migrations\Migration';
+
+    public const string MISSING_UP_ERROR_MESSAGE = 'Migrations must define an "up()" method, even if its body is empty. Add an "up()" method to this migration.';
+
+    public const string MISSING_DOWN_ERROR_MESSAGE = 'Migrations must define a "down()" method, even if its body is empty. Add a "down()" method to this migration.';
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return array<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if ($classReflection->isAbstract()) {
+            return [];
+        }
+
+        if (! $classReflection->isSubclassOf(self::MIGRATION_CLASS)) {
+            return [];
+        }
+
+        $methodNames = [];
+
+        foreach ($node->getOriginalNode()->getMethods() as $method) {
+            $methodNames[$method->name->toLowerString()] = true;
+        }
+
+        $errors = [];
+
+        if (! isset($methodNames['up'])) {
+            $errors[] = RuleErrorBuilder::message(self::MISSING_UP_ERROR_MESSAGE)
+                ->identifier('Common.migrationMissingUpMethod')
+                ->build();
+        }
+
+        if (! isset($methodNames['down'])) {
+            $errors[] = RuleErrorBuilder::message(self::MISSING_DOWN_ERROR_MESSAGE)
+                ->identifier('Common.migrationMissingDownMethod')
+                ->build();
+        }
+
+        return $errors;
+    }
+}

--- a/src/Rules/NoBlueprintAfterGrouping/NoBlueprintAfterGroupingRule.php
+++ b/src/Rules/NoBlueprintAfterGrouping/NoBlueprintAfterGroupingRule.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\NoBlueprintAfterGrouping;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * Flags Blueprint "->after()" column groupings that the FlattenAfterColumnGroupingRector
+ * cannot rewrite automatically, so they are surfaced for manual restructuring.
+ *
+ * The "auto-flattenable" conditions below are intentionally kept identical to
+ * CanyonGBS\Common\Rector\FlattenAfterColumnGroupingRector — keep the two in sync.
+ *
+ * @implements Rule<MethodCall>
+ */
+class NoBlueprintAfterGroupingRule implements Rule
+{
+    public const string ERROR_MESSAGE = 'The Blueprint "after()" column grouping cannot be automatically flattened here. Restructure the migration to define the columns directly, as PostgreSQL does not support positioning columns.';
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     *
+     * @return array<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        if ($node->name->toLowerString() !== 'after') {
+            return [];
+        }
+
+        if (! (new ObjectType('Illuminate\Database\Schema\Blueprint'))->isSuperTypeOf($scope->getType($node->var))->yes()) {
+            return [];
+        }
+
+        $arguments = $node->getArgs();
+
+        if (count($arguments) < 2) {
+            return [];
+        }
+
+        $callback = $arguments[1]->value;
+
+        if (! $callback instanceof Closure && ! $callback instanceof ArrowFunction) {
+            return [];
+        }
+
+        if ($this->isAutoFlattenable($node, $callback)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                ->identifier('Common.blueprintAfterGrouping')
+                ->build(),
+        ];
+    }
+
+    private function isAutoFlattenable(MethodCall $node, Closure|ArrowFunction $callback): bool
+    {
+        if (! $node->var instanceof Variable || ! is_string($node->var->name)) {
+            return false;
+        }
+
+        if (count($callback->params) < 1) {
+            return false;
+        }
+
+        $innerParameter = $callback->params[0]->var;
+
+        if (! $innerParameter instanceof Variable || ! is_string($innerParameter->name)) {
+            return false;
+        }
+
+        $outerName = $node->var->name;
+        $innerName = $innerParameter->name;
+
+        if ($innerName === $outerName) {
+            return true;
+        }
+
+        $statements = $callback instanceof Closure ? $callback->stmts : [$callback->expr];
+
+        return ! $this->bodyUsesVariableNamed($statements, $outerName);
+    }
+
+    /**
+     * @param array<Node> $statements
+     */
+    private function bodyUsesVariableNamed(array $statements, string $name): bool
+    {
+        $match = (new NodeFinder())->findFirst(
+            $statements,
+            fn (Node $node): bool => $node instanceof Variable && is_string($node->name) && $node->name === $name,
+        );
+
+        return $match !== null;
+    }
+}

--- a/src/Rules/NoJsonColumnInMigration/NoJsonColumnInMigrationRule.php
+++ b/src/Rules/NoJsonColumnInMigration/NoJsonColumnInMigrationRule.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\NoJsonColumnInMigration;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * Flags Blueprint "->json()" column definitions in migrations, as PostgreSQL almost always
+ * benefits from a "jsonb" column instead. When a "json" column is genuinely required, the
+ * rule can be silenced with a specific inline ignore.
+ *
+ * @implements Rule<MethodCall>
+ */
+class NoJsonColumnInMigrationRule implements Rule
+{
+    public const string ERROR_MESSAGE = 'Migrations should almost always use jsonb() instead of json(). Replace json() with jsonb(). If you are certain you specifically need a json column, add an inline ignore for this rule (// @phpstan-ignore Common.jsonColumnInMigration).';
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     *
+     * @return array<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        if ($node->name->toLowerString() !== 'json') {
+            return [];
+        }
+
+        if (! (new ObjectType('Illuminate\Database\Schema\Blueprint'))->isSuperTypeOf($scope->getType($node->var))->yes()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                ->identifier('Common.jsonColumnInMigration')
+                ->build(),
+        ];
+    }
+}

--- a/tests/PHPStan/Fixtures/AnonymousMigrationMissingDownFixture.php
+++ b/tests/PHPStan/Fixtures/AnonymousMigrationMissingDownFixture.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void {}
+};

--- a/tests/PHPStan/Fixtures/AnonymousMigrationWithUpAndDownFixture.php
+++ b/tests/PHPStan/Fixtures/AnonymousMigrationWithUpAndDownFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void {}
+
+    public function down(): void {}
+};

--- a/tests/PHPStan/Fixtures/BlueprintAfterGroupingFlattenableFixture.php
+++ b/tests/PHPStan/Fixtures/BlueprintAfterGroupingFlattenableFixture.php
@@ -34,19 +34,11 @@
 </COPYRIGHT>
 */
 
-use CanyonGBS\Common\Rector\CommonSetList;
-use Rector\Config\RectorConfig;
+use Illuminate\Database\Schema\Blueprint;
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-        __DIR__ . '/workbench',
-    ])
-    ->withSkip([
-        __DIR__ . '/tests/Rector/*/Fixtures',
-        __DIR__ . '/tests/PHPStan/Fixtures',
-    ])
-    ->withSets([
-        CommonSetList::COMMON,
-    ]);
+function addColumnsViaGrouping(Blueprint $table): void
+{
+    $table->after('first_name', function (Blueprint $table): void {
+        $table->string('middle_name');
+    });
+}

--- a/tests/PHPStan/Fixtures/BlueprintAfterGroupingNonVariableReceiverFixture.php
+++ b/tests/PHPStan/Fixtures/BlueprintAfterGroupingNonVariableReceiverFixture.php
@@ -34,19 +34,19 @@
 </COPYRIGHT>
 */
 
-use CanyonGBS\Common\Rector\CommonSetList;
-use Rector\Config\RectorConfig;
+use Illuminate\Database\Schema\Blueprint;
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-        __DIR__ . '/workbench',
-    ])
-    ->withSkip([
-        __DIR__ . '/tests/Rector/*/Fixtures',
-        __DIR__ . '/tests/PHPStan/Fixtures',
-    ])
-    ->withSets([
-        CommonSetList::COMMON,
-    ]);
+class AddsColumnsViaProperty
+{
+    public function __construct(
+        private Blueprint $table,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        $this->table->after('first_name', function (Blueprint $table): void {
+            $table->string('middle_name');
+        });
+    }
+}

--- a/tests/PHPStan/Fixtures/BlueprintAfterGroupingNonVariableReceiverFixture.php
+++ b/tests/PHPStan/Fixtures/BlueprintAfterGroupingNonVariableReceiverFixture.php
@@ -40,8 +40,7 @@ class AddsColumnsViaProperty
 {
     public function __construct(
         private Blueprint $table,
-    ) {
-    }
+    ) {}
 
     public function handle(): void
     {

--- a/tests/PHPStan/Fixtures/BlueprintColumnModifierAfterFixture.php
+++ b/tests/PHPStan/Fixtures/BlueprintColumnModifierAfterFixture.php
@@ -34,19 +34,9 @@
 </COPYRIGHT>
 */
 
-use CanyonGBS\Common\Rector\CommonSetList;
-use Rector\Config\RectorConfig;
+use Illuminate\Database\Schema\Blueprint;
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-        __DIR__ . '/workbench',
-    ])
-    ->withSkip([
-        __DIR__ . '/tests/Rector/*/Fixtures',
-        __DIR__ . '/tests/PHPStan/Fixtures',
-    ])
-    ->withSets([
-        CommonSetList::COMMON,
-    ]);
+function addColumnViaModifier(Blueprint $table): void
+{
+    $table->string('middle_name')->after('first_name');
+}

--- a/tests/PHPStan/Fixtures/JsonColumnIgnoredFixture.php
+++ b/tests/PHPStan/Fixtures/JsonColumnIgnoredFixture.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Schema\Blueprint;
+
+function addIgnoredJsonColumn(Blueprint $table): void
+{
+    $table->json('data'); // @phpstan-ignore Common.jsonColumnInMigration (We specifically need a json column here.)
+}

--- a/tests/PHPStan/Fixtures/JsonColumnInMigrationFixture.php
+++ b/tests/PHPStan/Fixtures/JsonColumnInMigrationFixture.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Schema\Blueprint;
+
+function addJsonColumn(Blueprint $table): void
+{
+    $table->json('data');
+}

--- a/tests/PHPStan/Fixtures/JsonColumnNonBlueprintFixture.php
+++ b/tests/PHPStan/Fixtures/JsonColumnNonBlueprintFixture.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+class JsonResponder
+{
+    public function json(string $value): string
+    {
+        return $value;
+    }
+}
+
+function respondWithJson(JsonResponder $responder): string
+{
+    return $responder->json('data');
+}

--- a/tests/PHPStan/Fixtures/JsonColumnViaPropertyFixture.php
+++ b/tests/PHPStan/Fixtures/JsonColumnViaPropertyFixture.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Schema\Blueprint;
+
+class AddsJsonColumnViaProperty
+{
+    public function __construct(
+        private Blueprint $table,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        $this->table->json('data');
+    }
+}

--- a/tests/PHPStan/Fixtures/JsonColumnViaPropertyFixture.php
+++ b/tests/PHPStan/Fixtures/JsonColumnViaPropertyFixture.php
@@ -40,8 +40,7 @@ class AddsJsonColumnViaProperty
 {
     public function __construct(
         private Blueprint $table,
-    ) {
-    }
+    ) {}
 
     public function handle(): void
     {

--- a/tests/PHPStan/Fixtures/JsonbColumnInMigrationFixture.php
+++ b/tests/PHPStan/Fixtures/JsonbColumnInMigrationFixture.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Schema\Blueprint;
+
+function addJsonbColumn(Blueprint $table): void
+{
+    $table->jsonb('data');
+}

--- a/tests/PHPStan/Fixtures/MigrationMissingBothFixture.php
+++ b/tests/PHPStan/Fixtures/MigrationMissingBothFixture.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+
+class MigrationMissingBothFixture extends Migration
+{
+    public function someHelper(): void {}
+}

--- a/tests/PHPStan/Fixtures/MigrationMissingDownFixture.php
+++ b/tests/PHPStan/Fixtures/MigrationMissingDownFixture.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+
+class MigrationMissingDownFixture extends Migration
+{
+    public function up(): void {}
+}

--- a/tests/PHPStan/Fixtures/MigrationMissingUpFixture.php
+++ b/tests/PHPStan/Fixtures/MigrationMissingUpFixture.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+
+class MigrationMissingUpFixture extends Migration
+{
+    public function down(): void {}
+}

--- a/tests/PHPStan/Fixtures/MigrationWithUpAndDownFixture.php
+++ b/tests/PHPStan/Fixtures/MigrationWithUpAndDownFixture.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+
+class MigrationWithUpAndDownFixture extends Migration
+{
+    public function up(): void {}
+
+    public function down(): void {}
+}

--- a/tests/PHPStan/Fixtures/NonMigrationClassFixture.php
+++ b/tests/PHPStan/Fixtures/NonMigrationClassFixture.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+class NonMigrationClassFixture
+{
+    public function handle(): void {}
+}

--- a/tests/PHPStan/MigrationHasUpAndDownMethodsTest.php
+++ b/tests/PHPStan/MigrationHasUpAndDownMethodsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('does not report migrations that define both up() and down() methods', function () {
+    $result = runPhpStanOnMigrationHasUpAndDownMethodsFixture('tests/PHPStan/Fixtures/MigrationWithUpAndDownFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report migrations that define both up() and down().\nOutput: {$result['output']}");
+});
+
+it('reports migrations that are missing a down() method', function () {
+    $result = runPhpStanOnMigrationHasUpAndDownMethodsFixture('tests/PHPStan/Fixtures/MigrationMissingDownFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.migrationMissingDownMethod');
+    expect($result['output'])->not->toContain('Common.migrationMissingUpMethod');
+});
+
+it('reports migrations that are missing an up() method', function () {
+    $result = runPhpStanOnMigrationHasUpAndDownMethodsFixture('tests/PHPStan/Fixtures/MigrationMissingUpFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.migrationMissingUpMethod');
+    expect($result['output'])->not->toContain('Common.migrationMissingDownMethod');
+});
+
+it('reports migrations that are missing both up() and down() methods', function () {
+    $result = runPhpStanOnMigrationHasUpAndDownMethodsFixture('tests/PHPStan/Fixtures/MigrationMissingBothFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.migrationMissingUpMethod');
+    expect($result['output'])->toContain('Common.migrationMissingDownMethod');
+});
+
+it('does not report anonymous migrations that define both up() and down() methods', function () {
+    $result = runPhpStanOnMigrationHasUpAndDownMethodsFixture('tests/PHPStan/Fixtures/AnonymousMigrationWithUpAndDownFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report anonymous migrations that define both up() and down().\nOutput: {$result['output']}");
+});
+
+it('reports anonymous migrations that are missing a down() method', function () {
+    $result = runPhpStanOnMigrationHasUpAndDownMethodsFixture('tests/PHPStan/Fixtures/AnonymousMigrationMissingDownFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.migrationMissingDownMethod');
+});
+
+it('does not report classes that are not migrations', function () {
+    $result = runPhpStanOnMigrationHasUpAndDownMethodsFixture('tests/PHPStan/Fixtures/NonMigrationClassFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report classes that are not migrations.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnMigrationHasUpAndDownMethodsFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}

--- a/tests/PHPStan/NoBlueprintAfterGroupingTest.php
+++ b/tests/PHPStan/NoBlueprintAfterGroupingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('reports Blueprint after() groupings that cannot be automatically flattened', function () {
+    $result = runPhpStanOnBlueprintAfterGroupingFixture('tests/PHPStan/Fixtures/BlueprintAfterGroupingNonVariableReceiverFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.blueprintAfterGrouping');
+});
+
+it('does not report Blueprint after() groupings that can be automatically flattened', function () {
+    $result = runPhpStanOnBlueprintAfterGroupingFixture('tests/PHPStan/Fixtures/BlueprintAfterGroupingFlattenableFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report flattenable Blueprint after() groupings.\nOutput: {$result['output']}");
+});
+
+it('does not report the Blueprint after() column modifier', function () {
+    $result = runPhpStanOnBlueprintAfterGroupingFixture('tests/PHPStan/Fixtures/BlueprintColumnModifierAfterFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report the Blueprint after() column modifier.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnBlueprintAfterGroupingFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}

--- a/tests/PHPStan/NoJsonColumnInMigrationTest.php
+++ b/tests/PHPStan/NoJsonColumnInMigrationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('reports Blueprint json() column definitions in migrations', function () {
+    $result = runPhpStanOnJsonColumnInMigrationFixture('tests/PHPStan/Fixtures/JsonColumnInMigrationFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.jsonColumnInMigration');
+});
+
+it('reports Blueprint json() column definitions called on a property', function () {
+    $result = runPhpStanOnJsonColumnInMigrationFixture('tests/PHPStan/Fixtures/JsonColumnViaPropertyFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.jsonColumnInMigration');
+});
+
+it('does not report Blueprint jsonb() column definitions', function () {
+    $result = runPhpStanOnJsonColumnInMigrationFixture('tests/PHPStan/Fixtures/JsonbColumnInMigrationFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report jsonb() column definitions.\nOutput: {$result['output']}");
+});
+
+it('does not report json() calls on non-Blueprint receivers', function () {
+    $result = runPhpStanOnJsonColumnInMigrationFixture('tests/PHPStan/Fixtures/JsonColumnNonBlueprintFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report json() calls on non-Blueprint receivers.\nOutput: {$result['output']}");
+});
+
+it('allows json() column definitions silenced with a specific inline ignore', function () {
+    $result = runPhpStanOnJsonColumnInMigrationFixture('tests/PHPStan/Fixtures/JsonColumnIgnoredFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should respect the inline ignore for json() column definitions.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnJsonColumnInMigrationFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}

--- a/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_arrow_function.php.inc
+++ b/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_arrow_function.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('users', function (Blueprint $table) {
+    $table->after('first_name', fn (Blueprint $table) => $table->string('middle_name'));
+});
+
+?>
+-----
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('users', function (Blueprint $table) {
+    $table->string('middle_name');
+});
+
+?>

--- a/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_arrow_function_differing_name.php.inc
+++ b/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_arrow_function_differing_name.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('users', function (Blueprint $table) {
+    $table->after('first_name', fn (Blueprint $blueprint) => $blueprint->string('middle_name'));
+});
+
+?>
+-----
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('users', function (Blueprint $table) {
+    $table->string('middle_name');
+});
+
+?>

--- a/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_closure_with_use.php.inc
+++ b/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_closure_with_use.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+$length = 100;
+
+Schema::table('users', function (Blueprint $table) use ($length) {
+    $table->after('first_name', function (Blueprint $table) use ($length) {
+        $table->string('middle_name', $length);
+        $table->string('suffix', $length);
+    });
+});
+
+?>
+-----
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+$length = 100;
+
+Schema::table('users', function (Blueprint $table) use ($length) {
+    $table->string('middle_name', $length);
+    $table->string('suffix', $length);
+});
+
+?>

--- a/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_differing_name_closure.php.inc
+++ b/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_differing_name_closure.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('users', function (Blueprint $table) {
+    $table->after('first_name', function (Blueprint $blueprint) {
+        $blueprint->string('middle_name');
+        $blueprint->string('suffix');
+    });
+});
+
+?>
+-----
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('users', function (Blueprint $table) {
+    $table->string('middle_name');
+    $table->string('suffix');
+});
+
+?>

--- a/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_nested_grouping.php.inc
+++ b/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_nested_grouping.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('users', function (Blueprint $table) {
+    $table->after('first_name', function (Blueprint $table) {
+        $table->string('middle_name');
+        $table->after('middle_name', function (Blueprint $table) {
+            $table->string('suffix');
+        });
+    });
+});
+
+?>
+-----
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('users', function (Blueprint $table) {
+    $table->string('middle_name');
+    $table->string('suffix');
+});
+
+?>

--- a/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_same_name_closure.php.inc
+++ b/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/flatten_same_name_closure.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('users', function (Blueprint $table) {
+    $table->after('first_name', function (Blueprint $table) {
+        $table->string('middle_name');
+        $table->string('suffix');
+    });
+});
+
+?>
+-----
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('users', function (Blueprint $table) {
+    $table->string('middle_name');
+    $table->string('suffix');
+});
+
+?>

--- a/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/keeps_column_modifier_after.php.inc
+++ b/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/keeps_column_modifier_after.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('users', function (Blueprint $table) {
+    $table->string('middle_name')->after('first_name');
+});

--- a/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/keeps_non_variable_receiver.php.inc
+++ b/tests/Rector/FlattenAfterColumnGroupingRector/Fixtures/keeps_non_variable_receiver.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+
+final class MigrationWithBlueprintProperty
+{
+    public Blueprint $table;
+
+    public function addColumns(): void
+    {
+        $this->table->after('first_name', function (Blueprint $table) {
+            $table->string('middle_name');
+        });
+    }
+}

--- a/tests/Rector/FlattenAfterColumnGroupingRector/FlattenAfterColumnGroupingRectorTest.php
+++ b/tests/Rector/FlattenAfterColumnGroupingRector/FlattenAfterColumnGroupingRectorTest.php
@@ -34,19 +34,29 @@
 </COPYRIGHT>
 */
 
-use CanyonGBS\Common\Rector\CommonSetList;
-use Rector\Config\RectorConfig;
+namespace CanyonGBS\Common\Tests\Rector\FlattenAfterColumnGroupingRector;
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-        __DIR__ . '/workbench',
-    ])
-    ->withSkip([
-        __DIR__ . '/tests/Rector/*/Fixtures',
-        __DIR__ . '/tests/PHPStan/Fixtures',
-    ])
-    ->withSets([
-        CommonSetList::COMMON,
-    ]);
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FlattenAfterColumnGroupingRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        foreach (glob(__DIR__ . '/Fixtures/*.php.inc') as $filePath) {
+            yield basename($filePath, '.php.inc') => [$filePath];
+        }
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/FlattenAfterColumnGroupingRector/config/configured_rule.php
+++ b/tests/Rector/FlattenAfterColumnGroupingRector/config/configured_rule.php
@@ -34,19 +34,10 @@
 </COPYRIGHT>
 */
 
-use CanyonGBS\Common\Rector\CommonSetList;
+use CanyonGBS\Common\Rector\FlattenAfterColumnGroupingRector;
 use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-        __DIR__ . '/workbench',
-    ])
-    ->withSkip([
-        __DIR__ . '/tests/Rector/*/Fixtures',
-        __DIR__ . '/tests/PHPStan/Fixtures',
-    ])
-    ->withSets([
-        CommonSetList::COMMON,
+    ->withRules([
+        FlattenAfterColumnGroupingRector::class,
     ]);

--- a/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/keeps_after_grouping_closure.php.inc
+++ b/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/keeps_after_grouping_closure.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->after('first_name', function (Blueprint $table) {
+                $table->string('middle_name');
+                $table->string('suffix');
+            });
+        });
+    }
+};

--- a/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/keeps_after_on_other_typed_object.php.inc
+++ b/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/keeps_after_on_other_typed_object.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+final class ColumnTimeline
+{
+    public function after(string $point): self
+    {
+        return $this;
+    }
+}
+
+$timeline = new ColumnTimeline();
+$timeline->after('first_name');

--- a/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/keeps_unrelated_after_call.php.inc
+++ b/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/keeps_unrelated_after_call.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+function demo($value): void
+{
+    $value->after('first_name');
+}

--- a/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_following_nullable.php.inc
+++ b/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_following_nullable.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('middle_name')->nullable()->after('first_name');
+        });
+    }
+};
+
+?>
+-----
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('middle_name')->nullable();
+        });
+    }
+};
+
+?>

--- a/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_from_multiple_columns.php.inc
+++ b/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_from_multiple_columns.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('middle_name')->after('first_name');
+            $table->string('suffix')->after('last_name');
+        });
+    }
+};
+
+?>
+-----
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('middle_name');
+            $table->string('suffix');
+        });
+    }
+};
+
+?>

--- a/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_from_string_column.php.inc
+++ b/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_from_string_column.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('middle_name')->after('first_name');
+        });
+    }
+};
+
+?>
+-----
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('middle_name');
+        });
+    }
+};
+
+?>

--- a/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_in_down_method.php.inc
+++ b/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_in_down_method.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('middle_name')->after('first_name');
+        });
+    }
+};
+
+?>
+-----
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('middle_name');
+        });
+    }
+};
+
+?>

--- a/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_preceding_nullable.php.inc
+++ b/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_preceding_nullable.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('middle_name')->after('first_name')->nullable();
+        });
+    }
+};
+
+?>
+-----
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('middle_name')->nullable();
+        });
+    }
+};
+
+?>

--- a/tests/Rector/RemoveAfterColumnModifierRector/RemoveAfterColumnModifierRectorTest.php
+++ b/tests/Rector/RemoveAfterColumnModifierRector/RemoveAfterColumnModifierRectorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Tests\Rector\RemoveAfterColumnModifierRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveAfterColumnModifierRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        foreach (glob(__DIR__ . '/Fixtures/*.php.inc') as $filePath) {
+            yield basename($filePath, '.php.inc') => [$filePath];
+        }
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/RemoveAfterColumnModifierRector/config/configured_rule.php
+++ b/tests/Rector/RemoveAfterColumnModifierRector/config/configured_rule.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use CanyonGBS\Common\Rector\RemoveAfterColumnModifierRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([
+        RemoveAfterColumnModifierRector::class,
+    ]);

--- a/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/converts_bare_fake_call.php.inc
+++ b/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/converts_bare_fake_call.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ConvertsBareFakeCallFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'faker' => fake(),
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ConvertsBareFakeCallFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'faker' => $this->faker,
+        ];
+    }
+}
+
+?>

--- a/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/converts_fake_in_definition.php.inc
+++ b/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/converts_fake_in_definition.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ConvertsFakeInDefinitionFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ConvertsFakeInDefinitionFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+        ];
+    }
+}
+
+?>

--- a/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/converts_fake_in_state_closure.php.inc
+++ b/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/converts_fake_in_state_closure.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ConvertsFakeInStateClosureFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [];
+    }
+
+    public function published(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'title' => fake()->sentence(),
+        ]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ConvertsFakeInStateClosureFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [];
+    }
+
+    public function published(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'title' => $this->faker->sentence(),
+        ]);
+    }
+}
+
+?>

--- a/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/converts_multiple_fake_calls.php.inc
+++ b/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/converts_multiple_fake_calls.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ConvertsMultipleFakeCallsFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'first_name' => fake()->firstName(),
+            'last_name' => fake()->lastName(),
+            'email' => fake()->safeEmail(),
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ConvertsMultipleFakeCallsFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'first_name' => $this->faker->firstName(),
+            'last_name' => $this->faker->lastName(),
+            'email' => $this->faker->safeEmail(),
+        ];
+    }
+}
+
+?>

--- a/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/keeps_fake_in_plain_function.php.inc
+++ b/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/keeps_fake_in_plain_function.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector\Fixtures;
+
+function keeps_fake_in_plain_function(): string
+{
+    return fake()->name();
+}

--- a/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/keeps_fake_outside_factory.php.inc
+++ b/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/keeps_fake_outside_factory.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector\Fixtures;
+
+class KeepsFakeOutsideFactory
+{
+    public function values(): array
+    {
+        return [
+            'name' => fake()->name(),
+        ];
+    }
+}

--- a/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/keeps_fake_with_locale_argument.php.inc
+++ b/tests/Rector/UseFakerPropertyInFactoryRector/Fixtures/keeps_fake_with_locale_argument.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class KeepsFakeWithLocaleArgumentFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake('de_DE')->name(),
+        ];
+    }
+}

--- a/tests/Rector/UseFakerPropertyInFactoryRector/UseFakerPropertyInFactoryRectorTest.php
+++ b/tests/Rector/UseFakerPropertyInFactoryRector/UseFakerPropertyInFactoryRectorTest.php
@@ -34,22 +34,29 @@
 </COPYRIGHT>
 */
 
-namespace Workbench\Database\Factories;
+namespace CanyonGBS\Common\Tests\Rector\UseFakerPropertyInFactoryRector;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Workbench\App\Models\Article;
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-/** @extends Factory<Article> */
-class ArticleFactory extends Factory
+final class UseFakerPropertyInFactoryRectorTest extends AbstractRectorTestCase
 {
-    protected $model = Article::class;
-
-    /** @return array<string, mixed> */
-    public function definition(): array
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
     {
-        return [
-            'category_id' => CategoryFactory::new(),
-            'name' => $this->faker->sentence(),
-        ];
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        foreach (glob(__DIR__ . '/Fixtures/*.php.inc') as $filePath) {
+            yield basename($filePath, '.php.inc') => [$filePath];
+        }
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/tests/Rector/UseFakerPropertyInFactoryRector/config/configured_rule.php
+++ b/tests/Rector/UseFakerPropertyInFactoryRector/config/configured_rule.php
@@ -34,22 +34,10 @@
 </COPYRIGHT>
 */
 
-namespace Workbench\Database\Factories;
+use CanyonGBS\Common\Rector\UseFakerPropertyInFactoryRector;
+use Rector\Config\RectorConfig;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Workbench\App\Models\Article;
-
-/** @extends Factory<Article> */
-class ArticleFactory extends Factory
-{
-    protected $model = Article::class;
-
-    /** @return array<string, mixed> */
-    public function definition(): array
-    {
-        return [
-            'category_id' => CategoryFactory::new(),
-            'name' => $this->faker->sentence(),
-        ];
-    }
-}
+return RectorConfig::configure()
+    ->withRules([
+        UseFakerPropertyInFactoryRector::class,
+    ]);

--- a/workbench/database/factories/CategoryFactory.php
+++ b/workbench/database/factories/CategoryFactory.php
@@ -48,7 +48,7 @@ class CategoryFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
         ];
     }
 }

--- a/workbench/database/factories/CommentFactory.php
+++ b/workbench/database/factories/CommentFactory.php
@@ -48,7 +48,7 @@ class CommentFactory extends Factory
     public function definition(): array
     {
         return [
-            'body' => fake()->paragraph(),
+            'body' => $this->faker->paragraph(),
             'commentable_id' => ProjectFactory::new(),
             'commentable_type' => 'Workbench\App\Models\Project',
         ];

--- a/workbench/database/factories/DeploymentFactory.php
+++ b/workbench/database/factories/DeploymentFactory.php
@@ -49,7 +49,7 @@ class DeploymentFactory extends Factory
     {
         return [
             'task_id' => TaskFactory::new(),
-            'commit_hash' => fake()->sha1(),
+            'commit_hash' => $this->faker->sha1(),
         ];
     }
 }

--- a/workbench/database/factories/ImageFactory.php
+++ b/workbench/database/factories/ImageFactory.php
@@ -48,7 +48,7 @@ class ImageFactory extends Factory
     public function definition(): array
     {
         return [
-            'url' => fake()->url(),
+            'url' => $this->faker->url(),
             'imageable_id' => ProjectFactory::new(),
             'imageable_type' => 'Workbench\App\Models\Project',
         ];

--- a/workbench/database/factories/ProjectFactory.php
+++ b/workbench/database/factories/ProjectFactory.php
@@ -48,7 +48,7 @@ class ProjectFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->sentence(),
+            'name' => $this->faker->sentence(),
         ];
     }
 }

--- a/workbench/database/factories/ReviewFactory.php
+++ b/workbench/database/factories/ReviewFactory.php
@@ -49,7 +49,7 @@ class ReviewFactory extends Factory
     {
         return [
             'article_id' => ArticleFactory::new(),
-            'body' => fake()->paragraph(),
+            'body' => $this->faker->paragraph(),
         ];
     }
 }

--- a/workbench/database/factories/TagFactory.php
+++ b/workbench/database/factories/TagFactory.php
@@ -48,7 +48,7 @@ class TagFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
         ];
     }
 }

--- a/workbench/database/factories/TaskFactory.php
+++ b/workbench/database/factories/TaskFactory.php
@@ -49,7 +49,7 @@ class TaskFactory extends Factory
     {
         return [
             'project_id' => ProjectFactory::new(),
-            'name' => fake()->sentence(),
+            'name' => $this->faker->sentence(),
         ];
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Implements some of the approved PHPStan / Rector rules.

Rector Rules:
- Remove `->after()` from migration
- Flatten `->after('...', fn => ...)` usages to get rid of after
- Convert any usage of `fake()` in database factories to `$this->faker`

PHPStan Rules:
- Report on usage of `->after('...', fn => ...)` used in migrations.
    - This was needed because rector can't safely rewrite every way this can be written. So I made it skip when it is too risky and then added this PHPStan rule to catch remaining usages for a developer to manually fix
- Report the usage of `->json()` in migrations. Suggesting they either use  `->jsonb()` or specifically ignore the violation
- Require that all migrations have both an `up` and `down` method.

When this is eventually added to all the projects the rector rules (and all future rules we want going to all projects) can be enabled in the project via the provided set. Example:

```php
<?php

use CanyonGBS\Common\Rector\CommonSetList;
use Rector\Config\RectorConfig;

return RectorConfig::configure()
    ->withPaths([
        __DIR__ . '/app',
        __DIR__ . '/database',
    ])
    ->withSets([
        CommonSetList::COMMON,
    ]);
```

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/common/blob/main/README.md#contributing).
