### PR TITLE
[Chore]: Add more team approved and designed Rector and PHPStan rules

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ resources/lang/**/*.php
 resources/js/dist/**
 **/vendor/
 **/*.php.inc
+tests/**/Fixtures/

--- a/php-cs-fixer.php
+++ b/php-cs-fixer.php
@@ -175,6 +175,7 @@ $finder = Finder::create()
     )
     ->name('*.php')
     ->notName('*.blade.php')
+    ->notPath('#tests/.+/Fixtures/#')
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -16,6 +16,13 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: CanyonGBS\Common\Rules\FeatureFlagConventions\FeatureFlagConventionsRule
+        arguments:
+            baseClasses: %featureFlagBaseClasses%
+            featuresNamespace: %featuresNamespace%
+        tags:
+            - phpstan.rules.rule
+    -
         class: CanyonGBS\Common\Rules\MigrationHasUpAndDownMethods\MigrationHasUpAndDownMethodsRule
         tags:
             - phpstan.rules.rule
@@ -27,3 +34,13 @@ services:
         class: CanyonGBS\Common\Rules\NoJsonColumnInMigration\NoJsonColumnInMigrationRule
         tags:
             - phpstan.rules.rule
+
+parameters:
+    featureFlagBaseClasses:
+        - App\Support\AbstractFeatureFlag
+        - App\Support\LandlordAbstractFeatureFlag
+    featuresNamespace: App\Features
+
+parametersSchema:
+    featureFlagBaseClasses: listOf(string())
+    featuresNamespace: string()

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -31,6 +31,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: CanyonGBS\Common\Rules\MultipleMigrationChangesWrappedInTransaction\MultipleMigrationChangesWrappedInTransactionRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: CanyonGBS\Common\Rules\NoBlueprintAfterGrouping\NoBlueprintAfterGroupingRule
         tags:
             - phpstan.rules.rule

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -35,6 +35,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: CanyonGBS\Common\Rules\NoLocalModelScope\NoLocalModelScopeRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: CanyonGBS\Common\Rules\NoJsonColumnInMigration\NoJsonColumnInMigrationRule
         tags:
             - phpstan.rules.rule

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -42,6 +42,10 @@ services:
         class: CanyonGBS\Common\Rules\NoJsonColumnInMigration\NoJsonColumnInMigrationRule
         tags:
             - phpstan.rules.rule
+    -
+        class: CanyonGBS\Common\Rules\NoStrtolower\NoStrtolowerRule
+        tags:
+            - phpstan.rules.rule
 
 parameters:
     featureFlagBaseClasses:

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -27,6 +27,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: CanyonGBS\Common\Rules\ModelHasFillableAndNoGuarded\ModelHasFillableAndNoGuardedRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: CanyonGBS\Common\Rules\NoBlueprintAfterGrouping\NoBlueprintAfterGroupingRule
         tags:
             - phpstan.rules.rule

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -54,6 +54,10 @@ services:
         class: CanyonGBS\Common\Rules\NoStrtolower\NoStrtolowerRule
         tags:
             - phpstan.rules.rule
+    -
+        class: CanyonGBS\Common\Rules\ShouldBeUniqueJobMustDefineUniqueFor\ShouldBeUniqueJobMustDefineUniqueForRule
+        tags:
+            - phpstan.rules.rule
 
 parameters:
     featureFlagBaseClasses:

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -43,6 +43,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: CanyonGBS\Common\Rules\NoLocalModelScope\NoLocalScopeInTraitRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: CanyonGBS\Common\Rules\NoJsonColumnInMigration\NoJsonColumnInMigrationRule
         tags:
             - phpstan.rules.rule

--- a/src/Filament/Forms/RichContentPlugins/VideoRichContentPlugin.php
+++ b/src/Filament/Forms/RichContentPlugins/VideoRichContentPlugin.php
@@ -47,6 +47,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Support\Enums\Width;
 use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Str;
 use Tiptap\Core\Extension;
 
 class VideoRichContentPlugin implements RichContentPlugin
@@ -144,7 +145,7 @@ class VideoRichContentPlugin implements RichContentPlugin
     public static function detectVideoType(string $url): ?string
     {
         $host = parse_url($url, PHP_URL_HOST);
-        $host = $host ? strtolower($host) : '';
+        $host = $host ? Str::lower($host) : '';
 
         if (preg_match('/(?:youtube\.com|youtu\.be)$/i', $host)) {
             return 'youtube';
@@ -155,7 +156,7 @@ class VideoRichContentPlugin implements RichContentPlugin
         }
 
         $path = parse_url($url, PHP_URL_PATH) ?? '';
-        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        $extension = Str::lower(pathinfo($path, PATHINFO_EXTENSION));
 
         if (in_array($extension, ['mp4', 'webm', 'ogg', 'mov'])) {
             return 'video';

--- a/src/Models/Attributes/NotAudited.php
+++ b/src/Models/Attributes/NotAudited.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Models\Attributes;
+
+use Attribute;
+
+/**
+ * Marks an Eloquent model as intentionally excluded from auditing.
+ *
+ * Most models in our systems must implement "OwenIt\Auditing\Contracts\Auditable" so that
+ * changes to them are recorded. A small number of models that users do not interact with do
+ * not need to be audited, but that must always be a deliberate, senior-approved decision.
+ *
+ * Applying this attribute is that explicit, documented choice. It applies only to the exact
+ * class it is declared on and is never inherited by subclasses.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+class NotAudited
+{
+}

--- a/src/Models/Attributes/NotAudited.php
+++ b/src/Models/Attributes/NotAudited.php
@@ -49,6 +49,4 @@ use Attribute;
  * class it is declared on and is never inherited by subclasses.
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-class NotAudited
-{
-}
+class NotAudited {}

--- a/src/Parser/Part/AbstractPart.php
+++ b/src/Parser/Part/AbstractPart.php
@@ -36,6 +36,8 @@
 
 namespace CanyonGBS\Common\Parser\Part;
 
+use Illuminate\Support\Str;
+
 abstract class AbstractPart
 {
     /**
@@ -122,6 +124,6 @@ abstract class AbstractPart
             return mb_convert_case($matches[0], MB_CASE_TITLE, 'UTF-8');
         }
 
-        return ucfirst(strtolower($matches[0]));
+        return ucfirst(Str::lower($matches[0]));
     }
 }

--- a/src/Rules/FeatureFlagConventions/FeatureFlagConventionsRule.php
+++ b/src/Rules/FeatureFlagConventions/FeatureFlagConventionsRule.php
@@ -67,8 +67,7 @@ class FeatureFlagConventionsRule implements Rule
     public function __construct(
         private array $baseClasses,
         private string $featuresNamespace,
-    ) {
-    }
+    ) {}
 
     /**
      * @return class-string<Node>

--- a/src/Rules/FeatureFlagConventions/FeatureFlagConventionsRule.php
+++ b/src/Rules/FeatureFlagConventions/FeatureFlagConventionsRule.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\FeatureFlagConventions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Enforces the conventions for Laravel Pennant feature flag classes:
+ *
+ * 1. Every concrete class within the configured feature namespace (e.g. "App\Features")
+ *    must extend one of the configured feature flag base classes.
+ * 2. Every concrete class that extends one of the configured feature flag base classes
+ *    must have a name ending in "Feature".
+ *
+ * Abstract classes, interfaces, enums, and traits are ignored.
+ *
+ * @implements Rule<InClassNode>
+ */
+class FeatureFlagConventionsRule implements Rule
+{
+    public const string MUST_EXTEND_BASE_ERROR_MESSAGE = 'Classes in the "%s" namespace must extend one of the feature flag base classes: %s.';
+
+    public const string MUST_END_IN_FEATURE_ERROR_MESSAGE = 'Feature flag classes must have a name ending in "Feature".';
+
+    /**
+     * @param array<int, string> $baseClasses
+     */
+    public function __construct(
+        private array $baseClasses,
+        private string $featuresNamespace,
+    ) {
+    }
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return array<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if (! $classReflection->isClass()) {
+            return [];
+        }
+
+        if ($classReflection->isAbstract()) {
+            return [];
+        }
+
+        $className = $classReflection->getName();
+
+        $extendsBaseClass = false;
+
+        foreach ($this->baseClasses as $baseClass) {
+            if ($classReflection->isSubclassOf($baseClass)) {
+                $extendsBaseClass = true;
+
+                break;
+            }
+        }
+
+        $inFeaturesNamespace = str_starts_with($className, $this->featuresNamespace . '\\');
+
+        $errors = [];
+
+        if ($inFeaturesNamespace && ! $extendsBaseClass) {
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                self::MUST_EXTEND_BASE_ERROR_MESSAGE,
+                $this->featuresNamespace,
+                implode(', ', $this->baseClasses),
+            ))
+                ->identifier('Common.featureMustExtendFeatureFlagAbstracts')
+                ->build();
+        }
+
+        if ($extendsBaseClass && ! str_ends_with($classReflection->getNativeReflection()->getShortName(), 'Feature')) {
+            $errors[] = RuleErrorBuilder::message(self::MUST_END_IN_FEATURE_ERROR_MESSAGE)
+                ->identifier('Common.featureFlagClassMustEndInFeature')
+                ->build();
+        }
+
+        return $errors;
+    }
+}

--- a/src/Rules/ModelHasFillableAndNoGuarded/ModelHasFillableAndNoGuardedRule.php
+++ b/src/Rules/ModelHasFillableAndNoGuarded/ModelHasFillableAndNoGuardedRule.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\ModelHasFillableAndNoGuarded;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Ensures every Eloquent model (a subclass of Illuminate\Database\Eloquent\Model)
+ * defines a "$fillable" property and does NOT define a "$guarded" property. This keeps
+ * mass-assignment protection explicit and consistent across the codebase.
+ *
+ * A "$fillable" property may be inherited from a parent model (abstract or concrete);
+ * only the framework's default declarations on the base model are ignored. A "$guarded"
+ * property declared anywhere in the user-defined hierarchy is reported.
+ *
+ * Abstract models are skipped.
+ *
+ * @implements Rule<InClassNode>
+ */
+class ModelHasFillableAndNoGuardedRule implements Rule
+{
+    public const string MODEL_CLASS = 'Illuminate\Database\Eloquent\Model';
+
+    /**
+     * Declarations of "$fillable" / "$guarded" originating from these classes are the
+     * framework's defaults and do not count as user-defined.
+     *
+     * @var list<string>
+     */
+    public const array BASE_DECLARATIONS = [
+        'Illuminate\Database\Eloquent\Model',
+        'Illuminate\Database\Eloquent\Concerns\GuardsAttributes',
+    ];
+
+    public const string MISSING_FILLABLE_ERROR_MESSAGE = 'Eloquent models must define a "$fillable" property. Add a "$fillable" property to this model or a parent model.';
+
+    public const string HAS_GUARDED_ERROR_MESSAGE = 'Eloquent models must not define a "$guarded" property. Remove the "$guarded" property declared on "%s" and use "$fillable" instead.';
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return array<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if ($classReflection->isAbstract()) {
+            return [];
+        }
+
+        if (! $classReflection->isSubclassOf(self::MODEL_CLASS)) {
+            return [];
+        }
+
+        $errors = [];
+
+        if (! $this->isPropertyDefinedByUser($classReflection, 'fillable', $scope)) {
+            $errors[] = RuleErrorBuilder::message(self::MISSING_FILLABLE_ERROR_MESSAGE)
+                ->identifier('Common.modelMissingFillable')
+                ->build();
+        }
+
+        $guardedDeclaringClass = $this->userDefinedPropertyDeclaringClass($classReflection, 'guarded', $scope);
+
+        if ($guardedDeclaringClass !== null) {
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                self::HAS_GUARDED_ERROR_MESSAGE,
+                $guardedDeclaringClass,
+            ))
+                ->identifier('Common.modelHasGuarded')
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function isPropertyDefinedByUser(ClassReflection $classReflection, string $propertyName, Scope $scope): bool
+    {
+        return $this->userDefinedPropertyDeclaringClass($classReflection, $propertyName, $scope) !== null;
+    }
+
+    private function userDefinedPropertyDeclaringClass(ClassReflection $classReflection, string $propertyName, Scope $scope): ?string
+    {
+        if (! $classReflection->hasProperty($propertyName)) {
+            return null;
+        }
+
+        $declaringClass = $classReflection->getProperty($propertyName, $scope)->getDeclaringClass()->getName();
+
+        if (in_array($declaringClass, self::BASE_DECLARATIONS, true)) {
+            return null;
+        }
+
+        return $declaringClass;
+    }
+}

--- a/src/Rules/ModelMustBeAuditableOrNotAudited/ModelMustBeAuditableOrNotAuditedRule.php
+++ b/src/Rules/ModelMustBeAuditableOrNotAudited/ModelMustBeAuditableOrNotAuditedRule.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\ModelMustBeAuditableOrNotAudited;
+
+use CanyonGBS\Common\Models\Attributes\NotAudited;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Ensures every Eloquent model (a subclass of Illuminate\Database\Eloquent\Model) is either
+ * audited or has been explicitly, deliberately excluded from auditing.
+ *
+ * Most of our systems use "owen-it/laravel-auditing" to record changes to their models, so a
+ * model satisfies this rule when it implements "OwenIt\Auditing\Contracts\Auditable" (directly
+ * or through a parent class).
+ *
+ * Some models that users never interact with do not need to be audited. That must always be a
+ * distinct, senior-approved decision rather than something silently ignored, so the only other
+ * way to satisfy this rule is to apply the "#[NotAudited]" attribute directly to the model. The
+ * attribute is honoured only on the exact class it is declared on; it is not inherited by
+ * subclasses.
+ *
+ * This rule is intentionally NOT registered in the package's shared PHPStan extension. Projects
+ * opt in by adding it to the "rules:" section of their own PHPStan configuration, which allows
+ * the single project that does not use auditing to simply leave it out.
+ *
+ * Abstract models are skipped.
+ *
+ * @implements Rule<InClassNode>
+ */
+class ModelMustBeAuditableOrNotAuditedRule implements Rule
+{
+    public const string MODEL_CLASS = 'Illuminate\Database\Eloquent\Model';
+
+    public const string AUDITABLE_INTERFACE = 'OwenIt\Auditing\Contracts\Auditable';
+
+    public const string ERROR_MESSAGE = 'Eloquent models must implement "OwenIt\Auditing\Contracts\Auditable" so that changes to them are audited. Do NOT ignore or suppress this error. If this model genuinely should not be audited, that must be a deliberate decision approved by a senior engineer — in that case add the "#[\CanyonGBS\Common\Models\Attributes\NotAudited]" attribute to the model instead of ignoring this error.';
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return array<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if ($classReflection->isAbstract()) {
+            return [];
+        }
+
+        if (! $classReflection->isSubclassOf(self::MODEL_CLASS)) {
+            return [];
+        }
+
+        if ($this->isAuditable($classReflection)) {
+            return [];
+        }
+
+        if ($this->isMarkedNotAudited($classReflection)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                ->identifier('Common.modelMustBeAuditableOrNotAudited')
+                ->build(),
+        ];
+    }
+
+    private function isAuditable(ClassReflection $classReflection): bool
+    {
+        return $classReflection->implementsInterface(self::AUDITABLE_INTERFACE);
+    }
+
+    private function isMarkedNotAudited(ClassReflection $classReflection): bool
+    {
+        return $classReflection->getNativeReflection()->getAttributes(NotAudited::class) !== [];
+    }
+}

--- a/src/Rules/MultipleMigrationChangesWrappedInTransaction/MultipleMigrationChangesWrappedInTransactionRule.php
+++ b/src/Rules/MultipleMigrationChangesWrappedInTransaction/MultipleMigrationChangesWrappedInTransactionRule.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\MultipleMigrationChangesWrappedInTransaction;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags migration "up()" and "down()" methods that contain more than one root statement.
+ *
+ * We use PostgreSQL for all projects, which allows almost all data and schema changes to be
+ * performed inside a transaction. Migrations that make multiple changes should wrap them in a
+ * single "DB::transaction(...)" call so that, if any step fails, none of the other changes are
+ * committed. This keeps the migration idempotent and safe to re-run once the issue is fixed.
+ *
+ * A correctly wrapped migration method has exactly one root statement (the transaction call),
+ * so more than one root statement signals that the changes are not wrapped in a transaction.
+ *
+ * @implements Rule<InClassNode>
+ */
+class MultipleMigrationChangesWrappedInTransactionRule implements Rule
+{
+    public const string MIGRATION_CLASS = 'Illuminate\Database\Migrations\Migration';
+
+    public const string ERROR_MESSAGE = 'Migrations that make multiple changes must wrap them in a single "DB::transaction(...)" call so that a failure rolls back every change and the migration stays idempotent. Move the statements in this "%s()" method into a "DB::transaction(...)" closure.';
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return array<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if ($classReflection->isAbstract()) {
+            return [];
+        }
+
+        if (! $classReflection->isSubclassOf(self::MIGRATION_CLASS)) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($node->getOriginalNode()->getMethods() as $method) {
+            $methodName = $method->name->toLowerString();
+
+            if ($methodName !== 'up' && $methodName !== 'down') {
+                continue;
+            }
+
+            if (! $this->hasMultipleRootStatements($method)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $method->name->toString()))
+                ->identifier('Common.multipleMigrationChangesNotWrappedInTransaction')
+                ->line($method->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function hasMultipleRootStatements(ClassMethod $method): bool
+    {
+        if ($method->stmts === null) {
+            return false;
+        }
+
+        return count($method->stmts) > 1;
+    }
+}

--- a/src/Rules/NoLocalModelScope/DetectsLocalScopes.php
+++ b/src/Rules/NoLocalModelScope/DetectsLocalScopes.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\NoLocalModelScope;
+
+use PhpParser\Node\Stmt\ClassMethod;
+
+trait DetectsLocalScopes
+{
+    private function isLocalScope(ClassMethod $method): bool
+    {
+        if (preg_match('/^scope[A-Z]/', $method->name->toString()) === 1) {
+            return true;
+        }
+
+        foreach ($method->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if ($attr->name->toString() === NoLocalModelScopeRule::SCOPE_ATTRIBUTE_CLASS) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rules/NoLocalModelScope/NoLocalModelScopeRule.php
+++ b/src/Rules/NoLocalModelScope/NoLocalModelScopeRule.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\NoLocalModelScope;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Forbids defining Eloquent local scopes on models (a subclass of
+ * Illuminate\Database\Eloquent\Model).
+ *
+ * Local scopes are reported in both of their forms:
+ *
+ * - methods using the "scope" prefix convention (e.g. "scopeActive");
+ * - methods annotated with the Illuminate\Database\Eloquent\Attributes\Scope attribute.
+ *
+ * Local scopes rely on magic methods, which static analysis tools struggle to reason
+ * about. Tappable scopes should be used instead.
+ *
+ * Only methods declared directly on the class are inspected, so framework trait scopes
+ * (e.g. "scopeWithoutTrashed") and scopes inherited from a parent are not reported on
+ * every subclass.
+ *
+ * @implements Rule<InClassNode>
+ */
+class NoLocalModelScopeRule implements Rule
+{
+    public const string MODEL_CLASS = 'Illuminate\Database\Eloquent\Model';
+
+    public const string SCOPE_ATTRIBUTE_CLASS = 'Illuminate\Database\Eloquent\Attributes\Scope';
+
+    public const string ERROR_MESSAGE = 'Eloquent local scopes are not allowed. The "%s" method on "%s" defines a local scope, which relies on magic methods that static analysis cannot reason about. Use a tappable scope instead. See https://seankegel.com/elevate-your-laravel-eloquent-queries-with-tappable-scopes.';
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return array<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if (! $classReflection->isSubclassOf(self::MODEL_CLASS)) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($node->getOriginalNode()->getMethods() as $method) {
+            if (! $this->isLocalScope($method)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                self::ERROR_MESSAGE,
+                $method->name->toString(),
+                $classReflection->getName(),
+            ))
+                ->identifier('Common.noLocalModelScope')
+                ->line($method->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function isLocalScope(ClassMethod $method): bool
+    {
+        if (preg_match('/^scope[A-Z]/', $method->name->toString()) === 1) {
+            return true;
+        }
+
+        foreach ($method->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if ($attr->name->toString() === self::SCOPE_ATTRIBUTE_CLASS) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rules/NoLocalModelScope/NoLocalScopeInTraitRule.php
+++ b/src/Rules/NoLocalModelScope/NoLocalScopeInTraitRule.php
@@ -37,73 +37,59 @@
 namespace CanyonGBS\Common\Rules\NoLocalModelScope;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Node\InClassNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * Forbids defining Eloquent local scopes on models (a subclass of
- * Illuminate\Database\Eloquent\Model).
+ * Forbids defining Eloquent local scopes inside traits.
+ *
+ * A local scope defined in a trait would otherwise be smuggled onto a model by importing
+ * the trait, bypassing NoLocalModelScopeRule (which only inspects the methods declared
+ * directly on the model). The scope is reported once, at its definition in the trait,
+ * regardless of how many models use it.
  *
  * Local scopes are reported in both of their forms:
  *
  * - methods using the "scope" prefix convention (e.g. "scopeActive");
  * - methods annotated with the Illuminate\Database\Eloquent\Attributes\Scope attribute.
  *
- * Local scopes rely on magic methods, which static analysis tools struggle to reason
- * about. Tappable scopes should be used instead.
- *
- * Only methods declared directly on the class are inspected, so framework trait scopes
- * (e.g. "scopeWithoutTrashed") and scopes inherited from a parent are not reported on
- * every subclass. Local scopes defined inside a trait are reported separately by
- * NoLocalScopeInTraitRule, at the trait's own definition.
- *
- * @implements Rule<InClassNode>
+ * @implements Rule<Trait_>
  */
-class NoLocalModelScopeRule implements Rule
+class NoLocalScopeInTraitRule implements Rule
 {
     use DetectsLocalScopes;
-
-    public const string MODEL_CLASS = 'Illuminate\Database\Eloquent\Model';
-
-    public const string SCOPE_ATTRIBUTE_CLASS = 'Illuminate\Database\Eloquent\Attributes\Scope';
-
-    public const string ERROR_MESSAGE = 'Eloquent local scopes are not allowed. The "%s" method on "%s" defines a local scope, which relies on magic methods that static analysis cannot reason about. Use a tappable scope instead. See https://seankegel.com/elevate-your-laravel-eloquent-queries-with-tappable-scopes.';
 
     /**
      * @return class-string<Node>
      */
     public function getNodeType(): string
     {
-        return InClassNode::class;
+        return Trait_::class;
     }
 
     /**
-     * @param InClassNode $node
+     * @param Trait_ $node
      *
      * @return array<RuleError>
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        $classReflection = $node->getClassReflection();
-
-        if (! $classReflection->isSubclassOf(self::MODEL_CLASS)) {
-            return [];
-        }
+        $traitName = $node->namespacedName?->toString() ?? $node->name?->toString() ?? '';
 
         $errors = [];
 
-        foreach ($node->getOriginalNode()->getMethods() as $method) {
+        foreach ($node->getMethods() as $method) {
             if (! $this->isLocalScope($method)) {
                 continue;
             }
 
             $errors[] = RuleErrorBuilder::message(sprintf(
-                self::ERROR_MESSAGE,
+                NoLocalModelScopeRule::ERROR_MESSAGE,
                 $method->name->toString(),
-                $classReflection->getName(),
+                $traitName,
             ))
                 ->identifier('Common.noLocalModelScope')
                 ->line($method->getStartLine())

--- a/src/Rules/NoStrtolower/NoStrtolowerRule.php
+++ b/src/Rules/NoStrtolower/NoStrtolowerRule.php
@@ -34,71 +34,55 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Parser\Mapper;
+namespace CanyonGBS\Common\Rules\NoStrtolower;
 
-use CanyonGBS\Common\Parser\Part\AbstractPart;
-use Illuminate\Support\Str;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
 
-abstract class AbstractMapper
+/**
+ * Flags calls to the global strtolower() function. strtolower() is not multibyte-safe and can
+ * corrupt non-ASCII strings. Use Laravel's Str::lower() instead, or mb_strtolower() when a
+ * framework-free alternative is required. If you specifically need strtolower(), the rule can be
+ * silenced with a specific inline ignore.
+ *
+ * @implements Rule<FuncCall>
+ */
+class NoStrtolowerRule implements Rule
 {
-    /**
-     * @param array<int, string|AbstractPart> $parts
-     *
-     * @return array<int, string|AbstractPart>
-     */
-    abstract public function map(array $parts);
+    public const string ERROR_MESSAGE = 'Avoid strtolower() as it is not multibyte-safe. Use Laravel\'s Str::lower() instead, or mb_strtolower() if a framework-free alternative is required. If you are certain you specifically need strtolower(), add an inline ignore for this rule (// @phpstan-ignore Common.noStrtolower).';
 
     /**
-     * Checks if there are still unmapped parts left before the given position.
-     *
-     * @param array<int, mixed> $parts
-     * @param int $index
-     *
-     * @return bool
+     * @return class-string<Node>
      */
-    protected function hasUnmappedPartsBefore(array $parts, $index): bool
+    public function getNodeType(): string
     {
-        foreach ($parts as $key => $part) {
-            if ($key === $index) {
-                break;
-            }
-
-            if (! ($part instanceof AbstractPart)) {
-                return true;
-            }
-        }
-
-        return false;
+        return FuncCall::class;
     }
 
     /**
-     * @param class-string $type
-     * @param array<int, object> $parts
+     * @param FuncCall $node
      *
-     * @return int|false
+     * @return array<RuleError>
      */
-    protected function findFirstMapped(string $type, array $parts)
+    public function processNode(Node $node, Scope $scope): array
     {
-        $total = count($parts);
-
-        for ($idx = 0; $idx < $total; $idx++) {
-            if ($parts[$idx] instanceof $type) {
-                return $idx;
-            }
+        if (! $node->name instanceof Name) {
+            return [];
         }
 
-        return false;
-    }
+        if ($node->name->toLowerString() !== 'strtolower') {
+            return [];
+        }
 
-    /**
-     * get the registry lookup key for the given word
-     *
-     * @param string $word the word
-     *
-     * @return string the key
-     */
-    protected function getKey($word): string
-    {
-        return Str::lower(str_replace('.', '', $word));
+        return [
+            RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                ->identifier('Common.noStrtolower')
+                ->build(),
+        ];
     }
 }

--- a/src/Rules/ShouldBeUniqueJobMustDefineUniqueFor/ShouldBeUniqueJobMustDefineUniqueForRule.php
+++ b/src/Rules/ShouldBeUniqueJobMustDefineUniqueFor/ShouldBeUniqueJobMustDefineUniqueForRule.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\ShouldBeUniqueJobMustDefineUniqueFor;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Ensures every queued job that implements "Illuminate\Contracts\Queue\ShouldBeUnique"
+ * (directly, through inheritance, or via the more specific
+ * "Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing") defines a "uniqueFor" value.
+ *
+ * When a job is unique, Laravel acquires a lock so that no other instance of the same job is
+ * dispatched while one is already queued or running. If "uniqueFor" is not defined, Laravel
+ * falls back to a lock duration of "0", meaning the lock never expires on its own and is only
+ * released when the job finishes processing. If the worker dies catastrophically mid-process
+ * (out of memory, SIGKILL, fatal error, etc.) the lock is never released and the job can no
+ * longer be dispatched until the lock is cleared manually.
+ *
+ * Defining "uniqueFor" — as either a property or a method, whichever the job needs — gives the
+ * lock a maximum lifetime so it is eventually released even when a job fails badly.
+ *
+ * Abstract classes are skipped.
+ *
+ * @implements Rule<InClassNode>
+ */
+class ShouldBeUniqueJobMustDefineUniqueForRule implements Rule
+{
+    public const string SHOULD_BE_UNIQUE_INTERFACE = 'Illuminate\Contracts\Queue\ShouldBeUnique';
+
+    public const string ERROR_MESSAGE = 'Jobs that implement "Illuminate\Contracts\Queue\ShouldBeUnique" must define a "uniqueFor" property or method. Without it the unique lock never expires on its own, so a job that fails catastrophically mid-process can leave a lock that is never released and blocks all future dispatches. Add a "uniqueFor" property or method to this job or a parent class.';
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return array<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if ($classReflection->isAbstract()) {
+            return [];
+        }
+
+        if (! $classReflection->implementsInterface(self::SHOULD_BE_UNIQUE_INTERFACE)) {
+            return [];
+        }
+
+        if ($this->definesUniqueFor($classReflection)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                ->identifier('Common.shouldBeUniqueJobMustDefineUniqueFor')
+                ->build(),
+        ];
+    }
+
+    private function definesUniqueFor(ClassReflection $classReflection): bool
+    {
+        return $classReflection->hasProperty('uniqueFor') || $classReflection->hasMethod('uniqueFor');
+    }
+}

--- a/tests/PHPStan/CanBeArchivedExtensionTest.php
+++ b/tests/PHPStan/CanBeArchivedExtensionTest.php
@@ -71,7 +71,7 @@ function runPhpStan(string $filePath): array
 {
     $basePath = dirname(__DIR__, 2);
     $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
-    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/can-be-archived.neon');
     $file = escapeshellarg($filePath);
 
     $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";

--- a/tests/PHPStan/Configs/can-be-archived.neon
+++ b/tests/PHPStan/Configs/can-be-archived.neon
@@ -1,0 +1,12 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Support\PHPStan\CanBeArchivedExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+    -
+        class: CanyonGBS\Common\Support\PHPStan\CanBeArchivedRelationExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension

--- a/tests/PHPStan/Configs/delete-force-delete-restore-bulk-equivalents.neon
+++ b/tests/PHPStan/Configs/delete-force-delete-restore-bulk-equivalents.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\DeleteForceDeleteRestoreBulkEquivalents\DeleteForceDeleteRestoreBulkEquivalentsRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/feature-flag-conventions.neon
+++ b/tests/PHPStan/Configs/feature-flag-conventions.neon
@@ -1,0 +1,16 @@
+parameters:
+    level: 6
+    scanFiles:
+        - ../Fixtures/FeatureFlag/AbstractFeatureFlagStub.php
+        - ../Fixtures/FeatureFlag/LandlordAbstractFeatureFlagStub.php
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\FeatureFlagConventions\FeatureFlagConventionsRule
+        arguments:
+            baseClasses:
+                - App\Support\AbstractFeatureFlag
+                - App\Support\LandlordAbstractFeatureFlag
+            featuresNamespace: App\Features
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/migration-has-up-and-down-methods.neon
+++ b/tests/PHPStan/Configs/migration-has-up-and-down-methods.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\MigrationHasUpAndDownMethods\MigrationHasUpAndDownMethodsRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/model-has-fillable-and-no-guarded.neon
+++ b/tests/PHPStan/Configs/model-has-fillable-and-no-guarded.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\ModelHasFillableAndNoGuarded\ModelHasFillableAndNoGuardedRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/model-must-be-auditable-or-not-audited.neon
+++ b/tests/PHPStan/Configs/model-must-be-auditable-or-not-audited.neon
@@ -1,0 +1,10 @@
+parameters:
+    level: 6
+    scanFiles:
+        - ../Fixtures/Auditing/AuditableStub.php
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\ModelMustBeAuditableOrNotAudited\ModelMustBeAuditableOrNotAuditedRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/multiple-migration-changes-wrapped-in-transaction.neon
+++ b/tests/PHPStan/Configs/multiple-migration-changes-wrapped-in-transaction.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\MultipleMigrationChangesWrappedInTransaction\MultipleMigrationChangesWrappedInTransactionRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/no-blueprint-after-grouping.neon
+++ b/tests/PHPStan/Configs/no-blueprint-after-grouping.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\NoBlueprintAfterGrouping\NoBlueprintAfterGroupingRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/no-json-column-in-migration.neon
+++ b/tests/PHPStan/Configs/no-json-column-in-migration.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\NoJsonColumnInMigration\NoJsonColumnInMigrationRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/no-local-model-scope.neon
+++ b/tests/PHPStan/Configs/no-local-model-scope.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\NoLocalModelScope\NoLocalModelScopeRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/no-local-scope-in-trait.neon
+++ b/tests/PHPStan/Configs/no-local-scope-in-trait.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\NoLocalModelScope\NoLocalScopeInTraitRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/no-strtolower.neon
+++ b/tests/PHPStan/Configs/no-strtolower.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\NoStrtolower\NoStrtolowerRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/should-be-unique-job-must-define-unique-for.neon
+++ b/tests/PHPStan/Configs/should-be-unique-job-must-define-unique-for.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\ShouldBeUniqueJobMustDefineUniqueFor\ShouldBeUniqueJobMustDefineUniqueForRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Configs/where-has-closure-type.neon
+++ b/tests/PHPStan/Configs/where-has-closure-type.neon
@@ -1,0 +1,16 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Support\PHPStan\WhereHasClosureTypeExtension
+        tags:
+            - phpstan.methodParameterClosureTypeExtension
+    -
+        class: CanyonGBS\Common\Support\PHPStan\CanBeArchivedExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+    -
+        class: CanyonGBS\Common\Support\PHPStan\CanBeArchivedRelationExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension

--- a/tests/PHPStan/DeleteForceDeleteRestoreBulkEquivalentsTest.php
+++ b/tests/PHPStan/DeleteForceDeleteRestoreBulkEquivalentsTest.php
@@ -54,7 +54,7 @@ function runPhpStanOnPolicyFixture(string $filePath): array
 {
     $basePath = dirname(__DIR__, 2);
     $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
-    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/delete-force-delete-restore-bulk-equivalents.neon');
     $file = escapeshellarg($filePath);
 
     $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";

--- a/tests/PHPStan/FeatureFlagConventionsTest.php
+++ b/tests/PHPStan/FeatureFlagConventionsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('reports classes in the features namespace that do not extend a feature flag base class', function () {
+    $result = runPhpStanOnFeatureFlagConventionsFixture('tests/PHPStan/Fixtures/FeatureFlag/FeatureNotExtendingBaseFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.featureMustExtendFeatureFlagAbstracts');
+    expect($result['output'])->not->toContain('Common.featureFlagClassMustEndInFeature');
+});
+
+it('reports feature flag classes that do not end in "Feature"', function () {
+    $result = runPhpStanOnFeatureFlagConventionsFixture('tests/PHPStan/Fixtures/FeatureFlag/FeatureMissingSuffixFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.featureFlagClassMustEndInFeature');
+    expect($result['output'])->not->toContain('Common.featureMustExtendFeatureFlagAbstracts');
+});
+
+it('reports landlord feature flag classes that do not end in "Feature"', function () {
+    $result = runPhpStanOnFeatureFlagConventionsFixture('tests/PHPStan/Fixtures/FeatureFlag/LandlordFeatureMissingSuffixFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.featureFlagClassMustEndInFeature');
+    expect($result['output'])->not->toContain('Common.featureMustExtendFeatureFlagAbstracts');
+});
+
+it('reports feature flag classes that extend a base class outside the features namespace but are misnamed', function () {
+    $result = runPhpStanOnFeatureFlagConventionsFixture('tests/PHPStan/Fixtures/FeatureFlag/OutsideNamespaceExtendsBaseFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.featureFlagClassMustEndInFeature');
+    expect($result['output'])->not->toContain('Common.featureMustExtendFeatureFlagAbstracts');
+});
+
+it('does not report a valid feature flag class', function () {
+    $result = runPhpStanOnFeatureFlagConventionsFixture('tests/PHPStan/Fixtures/FeatureFlag/ValidFeatureFlagFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report a valid feature flag class.\nOutput: {$result['output']}");
+});
+
+it('does not report abstract feature flag classes in the features namespace', function () {
+    $result = runPhpStanOnFeatureFlagConventionsFixture('tests/PHPStan/Fixtures/FeatureFlag/AbstractFeatureInNamespaceFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report abstract feature flag classes.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnFeatureFlagConventionsFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}

--- a/tests/PHPStan/FeatureFlagConventionsTest.php
+++ b/tests/PHPStan/FeatureFlagConventionsTest.php
@@ -85,7 +85,7 @@ function runPhpStanOnFeatureFlagConventionsFixture(string $filePath): array
 {
     $basePath = dirname(__DIR__, 2);
     $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
-    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/feature-flag-conventions.neon');
     $file = escapeshellarg($filePath);
 
     $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";

--- a/tests/PHPStan/Fixtures/AbstractModelFixture.php
+++ b/tests/PHPStan/Fixtures/AbstractModelFixture.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class AbstractModelFixture extends Model {}

--- a/tests/PHPStan/Fixtures/AbstractModelWithLocalScopeFixture.php
+++ b/tests/PHPStan/Fixtures/AbstractModelWithLocalScopeFixture.php
@@ -34,19 +34,13 @@
 </COPYRIGHT>
 */
 
-use CanyonGBS\Common\Rector\CommonSetList;
-use Rector\Config\RectorConfig;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-        __DIR__ . '/workbench',
-    ])
-    ->withSkip([
-        __DIR__ . '/tests/*/Fixtures/*',
-        __DIR__ . '/tests/*/*/Fixtures/*',
-    ])
-    ->withSets([
-        CommonSetList::COMMON,
-    ]);
+abstract class AbstractModelWithLocalScopeFixture extends Model
+{
+    public function scopeActive(Builder $query): void
+    {
+        $query->where('active', true);
+    }
+}

--- a/tests/PHPStan/Fixtures/AbstractUniqueJobFixture.php
+++ b/tests/PHPStan/Fixtures/AbstractUniqueJobFixture.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+
+abstract class AbstractUniqueJobFixture implements ShouldBeUnique
+{
+}

--- a/tests/PHPStan/Fixtures/AnonymousMigrationMultipleStatementsFixture.php
+++ b/tests/PHPStan/Fixtures/AnonymousMigrationMultipleStatementsFixture.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('foo', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+        });
+
+        Schema::create('bar', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bar');
+
+        Schema::dropIfExists('foo');
+    }
+};

--- a/tests/PHPStan/Fixtures/Auditing/AuditableStub.php
+++ b/tests/PHPStan/Fixtures/Auditing/AuditableStub.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace OwenIt\Auditing\Contracts;
+
+interface Auditable
+{
+}

--- a/tests/PHPStan/Fixtures/Auditing/ModelImplementingAuditableFixture.php
+++ b/tests/PHPStan/Fixtures/Auditing/ModelImplementingAuditableFixture.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Model;
+use OwenIt\Auditing\Contracts\Auditable;
+
+class ModelImplementingAuditableFixture extends Model implements Auditable
+{
+}

--- a/tests/PHPStan/Fixtures/Auditing/ModelInheritingNotAuditedFromParentFixture.php
+++ b/tests/PHPStan/Fixtures/Auditing/ModelInheritingNotAuditedFromParentFixture.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use CanyonGBS\Common\Models\Attributes\NotAudited;
+use Illuminate\Database\Eloquent\Model;
+
+#[NotAudited]
+abstract class NotAuditedBaseModelFixture extends Model
+{
+}
+
+class ModelInheritingNotAuditedFromParentFixture extends NotAuditedBaseModelFixture
+{
+}

--- a/tests/PHPStan/Fixtures/Auditing/ModelMissingAuditingFixture.php
+++ b/tests/PHPStan/Fixtures/Auditing/ModelMissingAuditingFixture.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelMissingAuditingFixture extends Model
+{
+}

--- a/tests/PHPStan/Fixtures/Auditing/ModelWithNotAuditedAttributeFixture.php
+++ b/tests/PHPStan/Fixtures/Auditing/ModelWithNotAuditedAttributeFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use CanyonGBS\Common\Models\Attributes\NotAudited;
+use Illuminate\Database\Eloquent\Model;
+
+#[NotAudited]
+class ModelWithNotAuditedAttributeFixture extends Model
+{
+}

--- a/tests/PHPStan/Fixtures/FeatureFlag/AbstractFeatureFlagStub.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/AbstractFeatureFlagStub.php
@@ -36,6 +36,4 @@
 
 namespace App\Support;
 
-abstract class AbstractFeatureFlag
-{
-}
+abstract class AbstractFeatureFlag {}

--- a/tests/PHPStan/Fixtures/FeatureFlag/AbstractFeatureFlagStub.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/AbstractFeatureFlagStub.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Support;
+
+abstract class AbstractFeatureFlag
+{
+}

--- a/tests/PHPStan/Fixtures/FeatureFlag/AbstractFeatureInNamespaceFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/AbstractFeatureInNamespaceFixture.php
@@ -38,6 +38,4 @@ namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;
 
-abstract class AbstractExampleFeature extends AbstractFeatureFlag
-{
-}
+abstract class AbstractExampleFeature extends AbstractFeatureFlag {}

--- a/tests/PHPStan/Fixtures/FeatureFlag/AbstractFeatureInNamespaceFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/AbstractFeatureInNamespaceFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+abstract class AbstractExampleFeature extends AbstractFeatureFlag
+{
+}

--- a/tests/PHPStan/Fixtures/FeatureFlag/FeatureMissingSuffixFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/FeatureMissingSuffixFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class MissingSuffixFlag extends AbstractFeatureFlag
+{
+}

--- a/tests/PHPStan/Fixtures/FeatureFlag/FeatureMissingSuffixFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/FeatureMissingSuffixFixture.php
@@ -38,6 +38,4 @@ namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;
 
-class MissingSuffixFlag extends AbstractFeatureFlag
-{
-}
+class MissingSuffixFlag extends AbstractFeatureFlag {}

--- a/tests/PHPStan/Fixtures/FeatureFlag/FeatureNotExtendingBaseFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/FeatureNotExtendingBaseFixture.php
@@ -36,6 +36,4 @@
 
 namespace App\Features;
 
-class OrphanFeature
-{
-}
+class OrphanFeature {}

--- a/tests/PHPStan/Fixtures/FeatureFlag/FeatureNotExtendingBaseFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/FeatureNotExtendingBaseFixture.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Features;
+
+class OrphanFeature
+{
+}

--- a/tests/PHPStan/Fixtures/FeatureFlag/LandlordAbstractFeatureFlagStub.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/LandlordAbstractFeatureFlagStub.php
@@ -36,6 +36,4 @@
 
 namespace App\Support;
 
-abstract class LandlordAbstractFeatureFlag
-{
-}
+abstract class LandlordAbstractFeatureFlag {}

--- a/tests/PHPStan/Fixtures/FeatureFlag/LandlordAbstractFeatureFlagStub.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/LandlordAbstractFeatureFlagStub.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Support;
+
+abstract class LandlordAbstractFeatureFlag
+{
+}

--- a/tests/PHPStan/Fixtures/FeatureFlag/LandlordFeatureMissingSuffixFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/LandlordFeatureMissingSuffixFixture.php
@@ -38,6 +38,4 @@ namespace App\Features;
 
 use App\Support\LandlordAbstractFeatureFlag;
 
-class LandlordBrokenName extends LandlordAbstractFeatureFlag
-{
-}
+class LandlordBrokenName extends LandlordAbstractFeatureFlag {}

--- a/tests/PHPStan/Fixtures/FeatureFlag/LandlordFeatureMissingSuffixFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/LandlordFeatureMissingSuffixFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Features;
+
+use App\Support\LandlordAbstractFeatureFlag;
+
+class LandlordBrokenName extends LandlordAbstractFeatureFlag
+{
+}

--- a/tests/PHPStan/Fixtures/FeatureFlag/OutsideNamespaceExtendsBaseFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/OutsideNamespaceExtendsBaseFixture.php
@@ -38,6 +38,4 @@ namespace App\Other;
 
 use App\Support\AbstractFeatureFlag;
 
-class RogueFlag extends AbstractFeatureFlag
-{
-}
+class RogueFlag extends AbstractFeatureFlag {}

--- a/tests/PHPStan/Fixtures/FeatureFlag/OutsideNamespaceExtendsBaseFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/OutsideNamespaceExtendsBaseFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Other;
+
+use App\Support\AbstractFeatureFlag;
+
+class RogueFlag extends AbstractFeatureFlag
+{
+}

--- a/tests/PHPStan/Fixtures/FeatureFlag/ValidFeatureFlagFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/ValidFeatureFlagFixture.php
@@ -38,6 +38,4 @@ namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;
 
-class ExampleFeature extends AbstractFeatureFlag
-{
-}
+class ExampleFeature extends AbstractFeatureFlag {}

--- a/tests/PHPStan/Fixtures/FeatureFlag/ValidFeatureFlagFixture.php
+++ b/tests/PHPStan/Fixtures/FeatureFlag/ValidFeatureFlagFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class ExampleFeature extends AbstractFeatureFlag
+{
+}

--- a/tests/PHPStan/Fixtures/JobInheritingShouldBeUniqueMissingUniqueForFixture.php
+++ b/tests/PHPStan/Fixtures/JobInheritingShouldBeUniqueMissingUniqueForFixture.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+
+abstract class AbstractUniqueJobMissingUniqueForFixture implements ShouldBeUnique
+{
+}
+
+class JobInheritingShouldBeUniqueMissingUniqueForFixture extends AbstractUniqueJobMissingUniqueForFixture
+{
+    public function handle(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/JobInheritingUniqueForFixture.php
+++ b/tests/PHPStan/Fixtures/JobInheritingUniqueForFixture.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+
+abstract class AbstractUniqueJobWithUniqueForFixture implements ShouldBeUnique
+{
+    public int $uniqueFor = 3600;
+}
+
+class JobInheritingUniqueForFixture extends AbstractUniqueJobWithUniqueForFixture
+{
+    public function handle(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/JobMissingUniqueForFixture.php
+++ b/tests/PHPStan/Fixtures/JobMissingUniqueForFixture.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+
+class JobMissingUniqueForFixture implements ShouldBeUnique
+{
+    public function handle(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/JobNotUniqueFixture.php
+++ b/tests/PHPStan/Fixtures/JobNotUniqueFixture.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+class JobNotUniqueFixture
+{
+    public function handle(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/JobUniqueUntilProcessingMissingUniqueForFixture.php
+++ b/tests/PHPStan/Fixtures/JobUniqueUntilProcessingMissingUniqueForFixture.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
+
+class JobUniqueUntilProcessingMissingUniqueForFixture implements ShouldBeUniqueUntilProcessing
+{
+    public function handle(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/JobWithUniqueForMethodFixture.php
+++ b/tests/PHPStan/Fixtures/JobWithUniqueForMethodFixture.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+
+class JobWithUniqueForMethodFixture implements ShouldBeUnique
+{
+    public function handle(): void
+    {
+    }
+
+    public function uniqueFor(): int
+    {
+        return 3600;
+    }
+}

--- a/tests/PHPStan/Fixtures/JobWithUniqueForPropertyFixture.php
+++ b/tests/PHPStan/Fixtures/JobWithUniqueForPropertyFixture.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+
+class JobWithUniqueForPropertyFixture implements ShouldBeUnique
+{
+    public int $uniqueFor = 3600;
+
+    public function handle(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/MigrationEmptyBodyFixture.php
+++ b/tests/PHPStan/Fixtures/MigrationEmptyBodyFixture.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+
+class MigrationEmptyBodyFixture extends Migration
+{
+    public function up(): void
+    {
+    }
+
+    public function down(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/MigrationMultipleStatementsFixture.php
+++ b/tests/PHPStan/Fixtures/MigrationMultipleStatementsFixture.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class MigrationMultipleStatementsFixture extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('foo', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+        });
+
+        Schema::create('bar', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bar');
+
+        Schema::dropIfExists('foo');
+    }
+}

--- a/tests/PHPStan/Fixtures/MigrationSingleStatementFixture.php
+++ b/tests/PHPStan/Fixtures/MigrationSingleStatementFixture.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class MigrationSingleStatementFixture extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('foo', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('foo');
+    }
+}

--- a/tests/PHPStan/Fixtures/MigrationWrappedInTransactionFixture.php
+++ b/tests/PHPStan/Fixtures/MigrationWrappedInTransactionFixture.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class MigrationWrappedInTransactionFixture extends Migration
+{
+    public function up(): void
+    {
+        DB::transaction(function (): void {
+            Schema::create('foo', function (Blueprint $table): void {
+                $table->uuid('id')->primary();
+            });
+
+            Schema::create('bar', function (Blueprint $table): void {
+                $table->uuid('id')->primary();
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function (): void {
+            Schema::dropIfExists('bar');
+
+            Schema::dropIfExists('foo');
+        });
+    }
+}

--- a/tests/PHPStan/Fixtures/ModelInheritingFillableFromAbstractParentFixture.php
+++ b/tests/PHPStan/Fixtures/ModelInheritingFillableFromAbstractParentFixture.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class AbstractModelWithFillableFixture extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+    ];
+}
+
+class ModelInheritingFillableFromAbstractParentFixture extends AbstractModelWithFillableFixture {}

--- a/tests/PHPStan/Fixtures/ModelInheritingGuardedFromAbstractParentFixture.php
+++ b/tests/PHPStan/Fixtures/ModelInheritingGuardedFromAbstractParentFixture.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class AbstractModelWithGuardedFixture extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    protected $guarded = [];
+}
+
+class ModelInheritingGuardedFromAbstractParentFixture extends AbstractModelWithGuardedFixture {}

--- a/tests/PHPStan/Fixtures/ModelMissingFillableFixture.php
+++ b/tests/PHPStan/Fixtures/ModelMissingFillableFixture.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelMissingFillableFixture extends Model {}

--- a/tests/PHPStan/Fixtures/ModelWithFillableFixture.php
+++ b/tests/PHPStan/Fixtures/ModelWithFillableFixture.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelWithFillableFixture extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/tests/PHPStan/Fixtures/ModelWithGuardedAndNoFillableFixture.php
+++ b/tests/PHPStan/Fixtures/ModelWithGuardedAndNoFillableFixture.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelWithGuardedAndNoFillableFixture extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $guarded = [];
+}

--- a/tests/PHPStan/Fixtures/ModelWithGuardedFixture.php
+++ b/tests/PHPStan/Fixtures/ModelWithGuardedFixture.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelWithGuardedFixture extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    protected $guarded = [];
+}

--- a/tests/PHPStan/Fixtures/ModelWithLocalScopeFixture.php
+++ b/tests/PHPStan/Fixtures/ModelWithLocalScopeFixture.php
@@ -34,19 +34,13 @@
 </COPYRIGHT>
 */
 
-use CanyonGBS\Common\Rector\CommonSetList;
-use Rector\Config\RectorConfig;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-        __DIR__ . '/workbench',
-    ])
-    ->withSkip([
-        __DIR__ . '/tests/*/Fixtures/*',
-        __DIR__ . '/tests/*/*/Fixtures/*',
-    ])
-    ->withSets([
-        CommonSetList::COMMON,
-    ]);
+class ModelWithLocalScopeFixture extends Model
+{
+    public function scopeActive(Builder $query): void
+    {
+        $query->where('active', true);
+    }
+}

--- a/tests/PHPStan/Fixtures/ModelWithScopeAttributeFixture.php
+++ b/tests/PHPStan/Fixtures/ModelWithScopeAttributeFixture.php
@@ -34,19 +34,15 @@
 </COPYRIGHT>
 */
 
-use CanyonGBS\Common\Rector\CommonSetList;
-use Rector\Config\RectorConfig;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-        __DIR__ . '/workbench',
-    ])
-    ->withSkip([
-        __DIR__ . '/tests/*/Fixtures/*',
-        __DIR__ . '/tests/*/*/Fixtures/*',
-    ])
-    ->withSets([
-        CommonSetList::COMMON,
-    ]);
+class ModelWithScopeAttributeFixture extends Model
+{
+    #[Scope]
+    public function active(Builder $query): void
+    {
+        $query->where('active', true);
+    }
+}

--- a/tests/PHPStan/Fixtures/ModelWithoutLocalScopeFixture.php
+++ b/tests/PHPStan/Fixtures/ModelWithoutLocalScopeFixture.php
@@ -34,19 +34,12 @@
 </COPYRIGHT>
 */
 
-use CanyonGBS\Common\Rector\CommonSetList;
-use Rector\Config\RectorConfig;
+use Illuminate\Database\Eloquent\Model;
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-        __DIR__ . '/workbench',
-    ])
-    ->withSkip([
-        __DIR__ . '/tests/*/Fixtures/*',
-        __DIR__ . '/tests/*/*/Fixtures/*',
-    ])
-    ->withSets([
-        CommonSetList::COMMON,
-    ]);
+class ModelWithoutLocalScopeFixture extends Model
+{
+    public function isActive(): bool
+    {
+        return (bool) $this->getAttribute('active');
+    }
+}

--- a/tests/PHPStan/Fixtures/NonMigrationMultipleStatementsClassFixture.php
+++ b/tests/PHPStan/Fixtures/NonMigrationMultipleStatementsClassFixture.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+class NonMigrationMultipleStatementsClassFixture
+{
+    public function up(): void
+    {
+        $first = 1;
+
+        $second = 2;
+    }
+
+    public function down(): void
+    {
+        $first = 1;
+
+        $second = 2;
+    }
+}

--- a/tests/PHPStan/Fixtures/NonModelClassFixture.php
+++ b/tests/PHPStan/Fixtures/NonModelClassFixture.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+class NonModelClassFixture
+{
+    public string $name = 'example';
+}

--- a/tests/PHPStan/Fixtures/NonModelClassWithScopeMethodFixture.php
+++ b/tests/PHPStan/Fixtures/NonModelClassWithScopeMethodFixture.php
@@ -34,19 +34,10 @@
 </COPYRIGHT>
 */
 
-use CanyonGBS\Common\Rector\CommonSetList;
-use Rector\Config\RectorConfig;
-
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-        __DIR__ . '/workbench',
-    ])
-    ->withSkip([
-        __DIR__ . '/tests/*/Fixtures/*',
-        __DIR__ . '/tests/*/*/Fixtures/*',
-    ])
-    ->withSets([
-        CommonSetList::COMMON,
-    ]);
+class NonModelClassWithScopeMethodFixture
+{
+    public function scopeActive(): bool
+    {
+        return true;
+    }
+}

--- a/tests/PHPStan/Fixtures/StrLowerFixture.php
+++ b/tests/PHPStan/Fixtures/StrLowerFixture.php
@@ -34,71 +34,14 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Parser\Mapper;
-
-use CanyonGBS\Common\Parser\Part\AbstractPart;
 use Illuminate\Support\Str;
 
-abstract class AbstractMapper
+function toLowerWithStr(string $value): string
 {
-    /**
-     * @param array<int, string|AbstractPart> $parts
-     *
-     * @return array<int, string|AbstractPart>
-     */
-    abstract public function map(array $parts);
+    return Str::lower($value);
+}
 
-    /**
-     * Checks if there are still unmapped parts left before the given position.
-     *
-     * @param array<int, mixed> $parts
-     * @param int $index
-     *
-     * @return bool
-     */
-    protected function hasUnmappedPartsBefore(array $parts, $index): bool
-    {
-        foreach ($parts as $key => $part) {
-            if ($key === $index) {
-                break;
-            }
-
-            if (! ($part instanceof AbstractPart)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param class-string $type
-     * @param array<int, object> $parts
-     *
-     * @return int|false
-     */
-    protected function findFirstMapped(string $type, array $parts)
-    {
-        $total = count($parts);
-
-        for ($idx = 0; $idx < $total; $idx++) {
-            if ($parts[$idx] instanceof $type) {
-                return $idx;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * get the registry lookup key for the given word
-     *
-     * @param string $word the word
-     *
-     * @return string the key
-     */
-    protected function getKey($word): string
-    {
-        return Str::lower(str_replace('.', '', $word));
-    }
+function toLowerWithMbStrtolower(string $value): string
+{
+    return mb_strtolower($value);
 }

--- a/tests/PHPStan/Fixtures/StrtolowerFixture.php
+++ b/tests/PHPStan/Fixtures/StrtolowerFixture.php
@@ -34,71 +34,7 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Parser\Mapper;
-
-use CanyonGBS\Common\Parser\Part\AbstractPart;
-use Illuminate\Support\Str;
-
-abstract class AbstractMapper
+function toLowerWithStrtolower(string $value): string
 {
-    /**
-     * @param array<int, string|AbstractPart> $parts
-     *
-     * @return array<int, string|AbstractPart>
-     */
-    abstract public function map(array $parts);
-
-    /**
-     * Checks if there are still unmapped parts left before the given position.
-     *
-     * @param array<int, mixed> $parts
-     * @param int $index
-     *
-     * @return bool
-     */
-    protected function hasUnmappedPartsBefore(array $parts, $index): bool
-    {
-        foreach ($parts as $key => $part) {
-            if ($key === $index) {
-                break;
-            }
-
-            if (! ($part instanceof AbstractPart)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param class-string $type
-     * @param array<int, object> $parts
-     *
-     * @return int|false
-     */
-    protected function findFirstMapped(string $type, array $parts)
-    {
-        $total = count($parts);
-
-        for ($idx = 0; $idx < $total; $idx++) {
-            if ($parts[$idx] instanceof $type) {
-                return $idx;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * get the registry lookup key for the given word
-     *
-     * @param string $word the word
-     *
-     * @return string the key
-     */
-    protected function getKey($word): string
-    {
-        return Str::lower(str_replace('.', '', $word));
-    }
+    return strtolower($value);
 }

--- a/tests/PHPStan/Fixtures/StrtolowerIgnoredFixture.php
+++ b/tests/PHPStan/Fixtures/StrtolowerIgnoredFixture.php
@@ -34,71 +34,8 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Parser\Mapper;
-
-use CanyonGBS\Common\Parser\Part\AbstractPart;
-use Illuminate\Support\Str;
-
-abstract class AbstractMapper
+function toLowerWithIgnoredStrtolower(string $value): string
 {
-    /**
-     * @param array<int, string|AbstractPart> $parts
-     *
-     * @return array<int, string|AbstractPart>
-     */
-    abstract public function map(array $parts);
-
-    /**
-     * Checks if there are still unmapped parts left before the given position.
-     *
-     * @param array<int, mixed> $parts
-     * @param int $index
-     *
-     * @return bool
-     */
-    protected function hasUnmappedPartsBefore(array $parts, $index): bool
-    {
-        foreach ($parts as $key => $part) {
-            if ($key === $index) {
-                break;
-            }
-
-            if (! ($part instanceof AbstractPart)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param class-string $type
-     * @param array<int, object> $parts
-     *
-     * @return int|false
-     */
-    protected function findFirstMapped(string $type, array $parts)
-    {
-        $total = count($parts);
-
-        for ($idx = 0; $idx < $total; $idx++) {
-            if ($parts[$idx] instanceof $type) {
-                return $idx;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * get the registry lookup key for the given word
-     *
-     * @param string $word the word
-     *
-     * @return string the key
-     */
-    protected function getKey($word): string
-    {
-        return Str::lower(str_replace('.', '', $word));
-    }
+    // @phpstan-ignore Common.noStrtolower
+    return strtolower($value);
 }

--- a/tests/PHPStan/Fixtures/TraitWithLocalScopeFixture.php
+++ b/tests/PHPStan/Fixtures/TraitWithLocalScopeFixture.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait TraitWithLocalScopeFixture
+{
+    public function scopeActive(Builder $query): void
+    {
+        $query->where('active', true);
+    }
+}

--- a/tests/PHPStan/Fixtures/TraitWithScopeAttributeFixture.php
+++ b/tests/PHPStan/Fixtures/TraitWithScopeAttributeFixture.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+
+trait TraitWithScopeAttributeFixture
+{
+    #[Scope]
+    public function active(Builder $query): void
+    {
+        $query->where('active', true);
+    }
+}

--- a/tests/PHPStan/Fixtures/TraitWithoutLocalScopeFixture.php
+++ b/tests/PHPStan/Fixtures/TraitWithoutLocalScopeFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+trait TraitWithoutLocalScopeFixture
+{
+    public function isActive(): bool
+    {
+        return (bool) $this->getAttribute('active');
+    }
+}

--- a/tests/PHPStan/MigrationHasUpAndDownMethodsTest.php
+++ b/tests/PHPStan/MigrationHasUpAndDownMethodsTest.php
@@ -90,7 +90,7 @@ function runPhpStanOnMigrationHasUpAndDownMethodsFixture(string $filePath): arra
 {
     $basePath = dirname(__DIR__, 2);
     $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
-    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/migration-has-up-and-down-methods.neon');
     $file = escapeshellarg($filePath);
 
     $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";

--- a/tests/PHPStan/ModelHasFillableAndNoGuardedTest.php
+++ b/tests/PHPStan/ModelHasFillableAndNoGuardedTest.php
@@ -97,7 +97,7 @@ function runPhpStanOnModelHasFillableAndNoGuardedFixture(string $filePath): arra
 {
     $basePath = dirname(__DIR__, 2);
     $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
-    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/model-has-fillable-and-no-guarded.neon');
     $file = escapeshellarg($filePath);
 
     $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";

--- a/tests/PHPStan/ModelHasFillableAndNoGuardedTest.php
+++ b/tests/PHPStan/ModelHasFillableAndNoGuardedTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('does not report models that define a $fillable property and no $guarded property', function () {
+    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/ModelWithFillableFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report models that define a \$fillable property and no \$guarded property.\nOutput: {$result['output']}");
+});
+
+it('reports models that are missing a $fillable property', function () {
+    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/ModelMissingFillableFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.modelMissingFillable');
+    expect($result['output'])->not->toContain('Common.modelHasGuarded');
+});
+
+it('reports models that define a $guarded property', function () {
+    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/ModelWithGuardedFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.modelHasGuarded');
+    expect($result['output'])->not->toContain('Common.modelMissingFillable');
+});
+
+it('reports models that are missing a $fillable property and define a $guarded property', function () {
+    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/ModelWithGuardedAndNoFillableFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.modelMissingFillable');
+    expect($result['output'])->toContain('Common.modelHasGuarded');
+});
+
+it('does not report models that inherit a $fillable property from an abstract parent', function () {
+    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/ModelInheritingFillableFromAbstractParentFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report models that inherit a \$fillable property from an abstract parent.\nOutput: {$result['output']}");
+});
+
+it('reports models that inherit a $guarded property from an abstract parent', function () {
+    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/ModelInheritingGuardedFromAbstractParentFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.modelHasGuarded');
+    expect($result['output'])->not->toContain('Common.modelMissingFillable');
+});
+
+it('does not report abstract models', function () {
+    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/AbstractModelFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report abstract models.\nOutput: {$result['output']}");
+});
+
+it('does not report classes that are not models', function () {
+    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/NonModelClassFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report classes that are not models.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnModelHasFillableAndNoGuardedFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}

--- a/tests/PHPStan/ModelMustBeAuditableOrNotAuditedTest.php
+++ b/tests/PHPStan/ModelMustBeAuditableOrNotAuditedTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('does not report models that implement the Auditable contract', function () {
+    $result = runPhpStanOnModelMustBeAuditableOrNotAuditedFixture('tests/PHPStan/Fixtures/Auditing/ModelImplementingAuditableFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report models that implement the Auditable contract.\nOutput: {$result['output']}");
+});
+
+it('does not report models that are marked with the NotAudited attribute', function () {
+    $result = runPhpStanOnModelMustBeAuditableOrNotAuditedFixture('tests/PHPStan/Fixtures/Auditing/ModelWithNotAuditedAttributeFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report models marked with the #[NotAudited] attribute.\nOutput: {$result['output']}");
+});
+
+it('reports models that are neither Auditable nor marked with the NotAudited attribute', function () {
+    $result = runPhpStanOnModelMustBeAuditableOrNotAuditedFixture('tests/PHPStan/Fixtures/Auditing/ModelMissingAuditingFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.modelMustBeAuditableOrNotAudited');
+});
+
+it('reports concrete models that only inherit the NotAudited attribute from a parent', function () {
+    $result = runPhpStanOnModelMustBeAuditableOrNotAuditedFixture('tests/PHPStan/Fixtures/Auditing/ModelInheritingNotAuditedFromParentFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.modelMustBeAuditableOrNotAudited');
+});
+
+it('does not report abstract models', function () {
+    $result = runPhpStanOnModelMustBeAuditableOrNotAuditedFixture('tests/PHPStan/Fixtures/AbstractModelFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report abstract models.\nOutput: {$result['output']}");
+});
+
+it('does not report classes that are not models', function () {
+    $result = runPhpStanOnModelMustBeAuditableOrNotAuditedFixture('tests/PHPStan/Fixtures/NonModelClassFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report classes that are not models.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnModelMustBeAuditableOrNotAuditedFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/model-must-be-auditable-or-not-audited.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}

--- a/tests/PHPStan/MultipleMigrationChangesWrappedInTransactionTest.php
+++ b/tests/PHPStan/MultipleMigrationChangesWrappedInTransactionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('does not report migrations that wrap their changes in a transaction', function () {
+    $result = runPhpStanOnMultipleMigrationChangesWrappedInTransactionFixture('tests/PHPStan/Fixtures/MigrationWrappedInTransactionFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report migrations that wrap their changes in a transaction.\nOutput: {$result['output']}");
+});
+
+it('does not report migrations whose methods contain a single statement', function () {
+    $result = runPhpStanOnMultipleMigrationChangesWrappedInTransactionFixture('tests/PHPStan/Fixtures/MigrationSingleStatementFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report migrations whose methods contain a single statement.\nOutput: {$result['output']}");
+});
+
+it('does not report migrations with empty up() and down() bodies', function () {
+    $result = runPhpStanOnMultipleMigrationChangesWrappedInTransactionFixture('tests/PHPStan/Fixtures/MigrationEmptyBodyFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report migrations with empty up() and down() bodies.\nOutput: {$result['output']}");
+});
+
+it('reports migrations whose up() and down() methods contain multiple root statements', function () {
+    $result = runPhpStanOnMultipleMigrationChangesWrappedInTransactionFixture('tests/PHPStan/Fixtures/MigrationMultipleStatementsFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.multipleMigrationChangesNotWrappedInTransaction');
+    expect(substr_count($result['output'], '"identifier":"Common.multipleMigrationChangesNotWrappedInTransaction"'))->toBe(2);
+});
+
+it('reports anonymous migrations whose methods contain multiple root statements', function () {
+    $result = runPhpStanOnMultipleMigrationChangesWrappedInTransactionFixture('tests/PHPStan/Fixtures/AnonymousMigrationMultipleStatementsFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.multipleMigrationChangesNotWrappedInTransaction');
+});
+
+it('does not report non-migration classes whose methods contain multiple statements', function () {
+    $result = runPhpStanOnMultipleMigrationChangesWrappedInTransactionFixture('tests/PHPStan/Fixtures/NonMigrationMultipleStatementsClassFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report non-migration classes.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnMultipleMigrationChangesWrappedInTransactionFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/multiple-migration-changes-wrapped-in-transaction.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}

--- a/tests/PHPStan/NoJsonColumnInMigrationTest.php
+++ b/tests/PHPStan/NoJsonColumnInMigrationTest.php
@@ -73,7 +73,7 @@ function runPhpStanOnJsonColumnInMigrationFixture(string $filePath): array
 {
     $basePath = dirname(__DIR__, 2);
     $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
-    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/no-json-column-in-migration.neon');
     $file = escapeshellarg($filePath);
 
     $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";

--- a/tests/PHPStan/NoLocalModelScopeTest.php
+++ b/tests/PHPStan/NoLocalModelScopeTest.php
@@ -34,33 +34,49 @@
 </COPYRIGHT>
 */
 
-it('reports Blueprint after() groupings that cannot be automatically flattened', function () {
-    $result = runPhpStanOnBlueprintAfterGroupingFixture('tests/PHPStan/Fixtures/BlueprintAfterGroupingNonVariableReceiverFixture.php');
+it('reports models that define a local scope using the "scope" prefix convention', function () {
+    $result = runPhpStanOnNoLocalModelScopeFixture('tests/PHPStan/Fixtures/ModelWithLocalScopeFixture.php');
 
     expect($result['exitCode'])->not->toBe(0);
-    expect($result['output'])->toContain('Common.blueprintAfterGrouping');
+    expect($result['output'])->toContain('Common.noLocalModelScope');
+    expect($result['output'])->toContain('tappable scope');
 });
 
-it('does not report Blueprint after() groupings that can be automatically flattened', function () {
-    $result = runPhpStanOnBlueprintAfterGroupingFixture('tests/PHPStan/Fixtures/BlueprintAfterGroupingFlattenableFixture.php');
+it('reports models that define a local scope using the #[Scope] attribute', function () {
+    $result = runPhpStanOnNoLocalModelScopeFixture('tests/PHPStan/Fixtures/ModelWithScopeAttributeFixture.php');
 
-    expect($result['exitCode'])->toBe(0, "PHPStan should not report flattenable Blueprint after() groupings.\nOutput: {$result['output']}");
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.noLocalModelScope');
+    expect($result['output'])->toContain('tappable scope');
 });
 
-it('does not report the Blueprint after() column modifier', function () {
-    $result = runPhpStanOnBlueprintAfterGroupingFixture('tests/PHPStan/Fixtures/BlueprintColumnModifierAfterFixture.php');
+it('reports abstract models that define a local scope', function () {
+    $result = runPhpStanOnNoLocalModelScopeFixture('tests/PHPStan/Fixtures/AbstractModelWithLocalScopeFixture.php');
 
-    expect($result['exitCode'])->toBe(0, "PHPStan should not report the Blueprint after() column modifier.\nOutput: {$result['output']}");
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.noLocalModelScope');
+});
+
+it('does not report models that do not define a local scope', function () {
+    $result = runPhpStanOnNoLocalModelScopeFixture('tests/PHPStan/Fixtures/ModelWithoutLocalScopeFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report models that do not define a local scope.\nOutput: {$result['output']}");
+});
+
+it('does not report non-model classes that define a method using the "scope" prefix', function () {
+    $result = runPhpStanOnNoLocalModelScopeFixture('tests/PHPStan/Fixtures/NonModelClassWithScopeMethodFixture.php');
+
+    expect($result['output'])->not->toContain('Common.noLocalModelScope');
 });
 
 /**
  * @return array{exitCode: int, output: string}
  */
-function runPhpStanOnBlueprintAfterGroupingFixture(string $filePath): array
+function runPhpStanOnNoLocalModelScopeFixture(string $filePath): array
 {
     $basePath = dirname(__DIR__, 2);
     $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
-    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/no-blueprint-after-grouping.neon');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/no-local-model-scope.neon');
     $file = escapeshellarg($filePath);
 
     $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";

--- a/tests/PHPStan/NoLocalScopeInTraitTest.php
+++ b/tests/PHPStan/NoLocalScopeInTraitTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('reports traits that define a local scope using the "scope" prefix convention', function () {
+    $result = runPhpStanOnNoLocalScopeInTraitFixture('tests/PHPStan/Fixtures/TraitWithLocalScopeFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.noLocalModelScope');
+    expect($result['output'])->toContain('tappable scope');
+});
+
+it('reports traits that define a local scope using the #[Scope] attribute', function () {
+    $result = runPhpStanOnNoLocalScopeInTraitFixture('tests/PHPStan/Fixtures/TraitWithScopeAttributeFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.noLocalModelScope');
+    expect($result['output'])->toContain('tappable scope');
+});
+
+it('does not report traits that do not define a local scope', function () {
+    $result = runPhpStanOnNoLocalScopeInTraitFixture('tests/PHPStan/Fixtures/TraitWithoutLocalScopeFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report traits that do not define a local scope.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnNoLocalScopeInTraitFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/no-local-scope-in-trait.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}

--- a/tests/PHPStan/NoStrtolowerTest.php
+++ b/tests/PHPStan/NoStrtolowerTest.php
@@ -34,71 +34,41 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Parser\Mapper;
+it('reports calls to the global strtolower() function', function () {
+    $result = runPhpStanOnNoStrtolowerFixture('tests/PHPStan/Fixtures/StrtolowerFixture.php');
 
-use CanyonGBS\Common\Parser\Part\AbstractPart;
-use Illuminate\Support\Str;
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.noStrtolower');
+});
 
-abstract class AbstractMapper
+it('does not report Str::lower() or mb_strtolower() calls', function () {
+    $result = runPhpStanOnNoStrtolowerFixture('tests/PHPStan/Fixtures/StrLowerFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report Str::lower() or mb_strtolower() calls.\nOutput: {$result['output']}");
+});
+
+it('allows strtolower() calls silenced with a specific inline ignore', function () {
+    $result = runPhpStanOnNoStrtolowerFixture('tests/PHPStan/Fixtures/StrtolowerIgnoredFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should respect the inline ignore for strtolower() calls.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnNoStrtolowerFixture(string $filePath): array
 {
-    /**
-     * @param array<int, string|AbstractPart> $parts
-     *
-     * @return array<int, string|AbstractPart>
-     */
-    abstract public function map(array $parts);
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/no-strtolower.neon');
+    $file = escapeshellarg($filePath);
 
-    /**
-     * Checks if there are still unmapped parts left before the given position.
-     *
-     * @param array<int, mixed> $parts
-     * @param int $index
-     *
-     * @return bool
-     */
-    protected function hasUnmappedPartsBefore(array $parts, $index): bool
-    {
-        foreach ($parts as $key => $part) {
-            if ($key === $index) {
-                break;
-            }
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
 
-            if (! ($part instanceof AbstractPart)) {
-                return true;
-            }
-        }
+    exec($command, $outputLines, $exitCode);
 
-        return false;
-    }
-
-    /**
-     * @param class-string $type
-     * @param array<int, object> $parts
-     *
-     * @return int|false
-     */
-    protected function findFirstMapped(string $type, array $parts)
-    {
-        $total = count($parts);
-
-        for ($idx = 0; $idx < $total; $idx++) {
-            if ($parts[$idx] instanceof $type) {
-                return $idx;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * get the registry lookup key for the given word
-     *
-     * @param string $word the word
-     *
-     * @return string the key
-     */
-    protected function getKey($word): string
-    {
-        return Str::lower(str_replace('.', '', $word));
-    }
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
 }

--- a/tests/PHPStan/ShouldBeUniqueJobMustDefineUniqueForTest.php
+++ b/tests/PHPStan/ShouldBeUniqueJobMustDefineUniqueForTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('reports jobs implementing ShouldBeUnique that do not define uniqueFor', function () {
+    $result = runPhpStanOnShouldBeUniqueJobFixture('tests/PHPStan/Fixtures/JobMissingUniqueForFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.shouldBeUniqueJobMustDefineUniqueFor');
+    expect($result['output'])->toContain('uniqueFor');
+});
+
+it('reports jobs implementing ShouldBeUniqueUntilProcessing that do not define uniqueFor', function () {
+    $result = runPhpStanOnShouldBeUniqueJobFixture('tests/PHPStan/Fixtures/JobUniqueUntilProcessingMissingUniqueForFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.shouldBeUniqueJobMustDefineUniqueFor');
+});
+
+it('reports jobs that inherit ShouldBeUnique but do not define uniqueFor anywhere', function () {
+    $result = runPhpStanOnShouldBeUniqueJobFixture('tests/PHPStan/Fixtures/JobInheritingShouldBeUniqueMissingUniqueForFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.shouldBeUniqueJobMustDefineUniqueFor');
+});
+
+it('does not report jobs that define a uniqueFor property', function () {
+    $result = runPhpStanOnShouldBeUniqueJobFixture('tests/PHPStan/Fixtures/JobWithUniqueForPropertyFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report jobs that define a uniqueFor property.\nOutput: {$result['output']}");
+});
+
+it('does not report jobs that define a uniqueFor method', function () {
+    $result = runPhpStanOnShouldBeUniqueJobFixture('tests/PHPStan/Fixtures/JobWithUniqueForMethodFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report jobs that define a uniqueFor method.\nOutput: {$result['output']}");
+});
+
+it('does not report jobs that inherit a uniqueFor definition from a parent', function () {
+    $result = runPhpStanOnShouldBeUniqueJobFixture('tests/PHPStan/Fixtures/JobInheritingUniqueForFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report jobs that inherit a uniqueFor definition from a parent.\nOutput: {$result['output']}");
+});
+
+it('does not report classes that do not implement ShouldBeUnique', function () {
+    $result = runPhpStanOnShouldBeUniqueJobFixture('tests/PHPStan/Fixtures/JobNotUniqueFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report classes that do not implement ShouldBeUnique.\nOutput: {$result['output']}");
+});
+
+it('does not report abstract jobs that implement ShouldBeUnique', function () {
+    $result = runPhpStanOnShouldBeUniqueJobFixture('tests/PHPStan/Fixtures/AbstractUniqueJobFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report abstract jobs that implement ShouldBeUnique.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnShouldBeUniqueJobFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/should-be-unique-job-must-define-unique-for.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}

--- a/tests/PHPStan/WhereHasClosureTypeExtensionTest.php
+++ b/tests/PHPStan/WhereHasClosureTypeExtensionTest.php
@@ -67,7 +67,7 @@ function runPhpStanOnFixture(string $filePath): array
 {
     $basePath = dirname(__DIR__, 2);
     $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
-    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/where-has-closure-type.neon');
     $file = escapeshellarg($filePath);
 
     $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";

--- a/tests/PHPStan/phpstan-test.neon
+++ b/tests/PHPStan/phpstan-test.neon
@@ -3,3 +3,6 @@ includes:
 
 parameters:
     level: 6
+    scanFiles:
+        - Fixtures/FeatureFlag/AbstractFeatureFlagStub.php
+        - Fixtures/FeatureFlag/LandlordAbstractFeatureFlagStub.php

--- a/tests/PHPStan/phpstan-test.neon
+++ b/tests/PHPStan/phpstan-test.neon
@@ -1,8 +1,0 @@
-includes:
-    - ../../phpstan-extension.neon
-
-parameters:
-    level: 6
-    scanFiles:
-        - Fixtures/FeatureFlag/AbstractFeatureFlagStub.php
-        - Fixtures/FeatureFlag/LandlordAbstractFeatureFlagStub.php

--- a/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_from_string_column.php
+++ b/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_from_string_column.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_from_string_column.php
+++ b/tests/Rector/RemoveAfterColumnModifierRector/Fixtures/removes_after_from_string_column.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('middle_name')->after('first_name');
+        });
+    }
+};
+
+?>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Implements some of the approved PHPStan / Rector rules.

Rector Rules:
- 

PHPStan Rules:
- Ensures that all feature flag classes extend one of the base classes AND must end in the word `Feature`.
- Requires that all models must implement a `$fillable` property, either directly or via inheritance (skipping the root model class) AND requires that no model implement a `$guarded` property.
- Report on definition of local scopes in models, recommends to use tappable scopes instead
- Also report on definition of local scopes in traits, recommends to use tappable scopes instead
- Flags usage of `strtolower()` and recommends using Laravel's `Str::lower()` or `mb_strtolower()`
- Report on `up()` or `down()` methods that have multiple root statements. This indicates migrations that do multiple states outside of a transaction. If one step fails others may not be rolled back.
- Enforces that ALL models must either implement the Auditable interface OR specifically contain a new `NotAudited` attribute. Making audit assignment to models a conscious decision.
    - NOTE: Unlike ALL other rules in this repo this one DOES NOT get auto imported since some of our projects don't audit the models. So, this should be directly added to the rules list the PHPStan config of Advising App and Aiding App (`CanyonGBS\Common\Rules\ModelMustBeAuditableOrNotAudited\ModelMustBeAuditableOrNotAuditedRule`)
- Reports any class (job) implementing `ShouldBeUnique` that does not have a `uniqueFor` property or method.

Also updates all the PHPStan tests to use their own config per tests to prevent cross-pollution between the tests.

And also adds a bunch of ignores to make sure we don't scan / format Fixture files as they often have to stay exactly as they are to be valuable in testing.

NOTE: When we release this and update all the projects we also need to add MeliorStan `DevelopmentCodeFragment` to all the projects.
With that and the rules here that covers all currently proposed and accepted rules.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/common/blob/main/README.md#contributing).
