### PR TITLE
fix: Fillable/guarded rule with inheritance from vendor code

### DIFF
--- a/src/Rules/ModelHasFillableAndNoGuarded/ModelHasFillableAndNoGuardedRule.php
+++ b/src/Rules/ModelHasFillableAndNoGuarded/ModelHasFillableAndNoGuardedRule.php
@@ -50,10 +50,15 @@ use PHPStan\Rules\RuleErrorBuilder;
  * mass-assignment protection explicit and consistent across the codebase.
  *
  * A "$fillable" property may be inherited from a parent model (abstract or concrete);
- * only the framework's default declarations on the base model are ignored. A "$guarded"
- * property declared anywhere in the user-defined hierarchy is reported.
+ * only the framework's default declarations on the base model are ignored. A model that
+ * inherits a "$guarded" property from a parent is exempt from the "$fillable" requirement.
  *
- * Abstract models are skipped.
+ * A "$guarded" property is only reported when it is declared directly on the analyzed
+ * class; a "$guarded" property inherited from a parent is not reported (the parent is
+ * reported when it is analyzed itself). This includes abstract models: an abstract model
+ * that declares its own "$guarded" property is reported.
+ *
+ * Abstract models are exempt from the "$fillable" requirement.
  *
  * @implements Rule<InClassNode>
  */
@@ -93,25 +98,27 @@ class ModelHasFillableAndNoGuardedRule implements Rule
     {
         $classReflection = $node->getClassReflection();
 
-        if ($classReflection->isAbstract()) {
-            return [];
-        }
-
         if (! $classReflection->isSubclassOf(self::MODEL_CLASS)) {
             return [];
         }
 
         $errors = [];
 
-        if (! $this->isPropertyDefinedByUser($classReflection, 'fillable', $scope)) {
+        $guardedDeclaringClass = $this->userDefinedPropertyDeclaringClass($classReflection, 'guarded', $scope);
+        $hasOwnGuarded = $guardedDeclaringClass === $classReflection->getName();
+        $hasInheritedGuarded = $guardedDeclaringClass !== null && ! $hasOwnGuarded;
+
+        if (
+            ! $classReflection->isAbstract()
+            && ! $hasInheritedGuarded
+            && ! $this->isPropertyDefinedByUser($classReflection, 'fillable', $scope)
+        ) {
             $errors[] = RuleErrorBuilder::message(self::MISSING_FILLABLE_ERROR_MESSAGE)
                 ->identifier('Common.modelMissingFillable')
                 ->build();
         }
 
-        $guardedDeclaringClass = $this->userDefinedPropertyDeclaringClass($classReflection, 'guarded', $scope);
-
-        if ($guardedDeclaringClass !== null) {
+        if ($hasOwnGuarded) {
             $errors[] = RuleErrorBuilder::message(sprintf(
                 self::HAS_GUARDED_ERROR_MESSAGE,
                 $guardedDeclaringClass,

--- a/tests/PHPStan/Fixtures/AbstractModelWithGuardedFixture.php
+++ b/tests/PHPStan/Fixtures/AbstractModelWithGuardedFixture.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class AbstractModelWithGuardedFixture extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $guarded = [];
+}

--- a/tests/PHPStan/Fixtures/ModelExtendingPivotFixture.php
+++ b/tests/PHPStan/Fixtures/ModelExtendingPivotFixture.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class ModelExtendingPivotFixture extends Pivot
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/tests/PHPStan/Fixtures/ModelExtendingPivotWithoutFillableFixture.php
+++ b/tests/PHPStan/Fixtures/ModelExtendingPivotWithoutFillableFixture.php
@@ -34,21 +34,6 @@
 </COPYRIGHT>
 */
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
-abstract class AbstractModelWithGuardedFixture extends Model
-{
-    /**
-     * @var list<string>
-     */
-    protected $fillable = [
-        'name',
-    ];
-
-    /**
-     * @var list<string>
-     */
-    protected $guarded = [];
-}
-
-class ModelInheritingGuardedFromAbstractParentFixture extends AbstractModelWithGuardedFixture {}
+class ModelExtendingPivotWithoutFillableFixture extends Pivot {}

--- a/tests/PHPStan/ModelHasFillableAndNoGuardedTest.php
+++ b/tests/PHPStan/ModelHasFillableAndNoGuardedTest.php
@@ -70,8 +70,20 @@ it('does not report models that inherit a $fillable property from an abstract pa
     expect($result['exitCode'])->toBe(0, "PHPStan should not report models that inherit a \$fillable property from an abstract parent.\nOutput: {$result['output']}");
 });
 
-it('reports models that inherit a $guarded property from an abstract parent', function () {
-    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/ModelInheritingGuardedFromAbstractParentFixture.php');
+it('does not report models that extend Pivot and define a $fillable property', function () {
+    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/ModelExtendingPivotFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report models that extend Pivot and define a \$fillable property.\nOutput: {$result['output']}");
+});
+
+it('does not require a $fillable property for models that inherit a $guarded property from Pivot', function () {
+    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/ModelExtendingPivotWithoutFillableFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not require a \$fillable property for models that inherit a \$guarded property from Pivot.\nOutput: {$result['output']}");
+});
+
+it('reports abstract models that define a $guarded property', function () {
+    $result = runPhpStanOnModelHasFillableAndNoGuardedFixture('tests/PHPStan/Fixtures/AbstractModelWithGuardedFixture.php');
 
     expect($result['exitCode'])->not->toBe(0);
     expect($result['output'])->toContain('Common.modelHasGuarded');


### PR DESCRIPTION
Laravel defines `$guarded` on the base `Pivot` model, so any model extending that fails the existing checks.

These changes allow a model to extend a base model that has `$guarded` without causing errors. Enforcing `$fillable` on these child models is not useful either, since both properties apply and the `$guarded` means that all properties are fillable anyway.

Parent models that define `$guarded` still throw errors when scanned, if they are part of the app's codebase rather than a vendor class.