### PR TITLE
Add shared portal home Vue components

### DIFF
--- a/resources/js/components/portal/home/CategoryCard.vue
+++ b/resources/js/components/portal/home/CategoryCard.vue
@@ -1,10 +1,10 @@
 <!--
 <COPYRIGHT>
 
-    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
 
-    Advising App® is licensed under the Elastic License 2.0. For more details,
-    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
 
     Notice:
 
@@ -15,14 +15,14 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
-    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS® and Advising App® are registered trademarks of
-      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
       vigorously.
     - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS Inc.
+      Software as a Service (SaaS) by Canyon GBS LLC.
     - Use of this software implies agreement to the license terms and conditions as stated
       in the Elastic License 2.0.
 

--- a/resources/js/components/portal/home/CategoryCard.vue
+++ b/resources/js/components/portal/home/CategoryCard.vue
@@ -1,0 +1,80 @@
+<!--
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+-->
+<script setup>
+    import { ChevronRightIcon } from '@heroicons/vue/20/solid';
+
+    defineProps({
+        to: {
+            type: [Object, String],
+            required: true,
+        },
+        icon: {
+            type: String,
+            default: null,
+        },
+        name: {
+            type: String,
+            required: true,
+        },
+        description: {
+            type: String,
+            default: null,
+        },
+    });
+</script>
+
+<template>
+    <router-link
+        :to="to"
+        class="group flex items-start w-full gap-3 rounded-xl bg-white px-6 py-4 ring-1 ring-gray-950/5 transition duration-75 hover:bg-gray-50"
+    >
+        <div
+            v-if="icon"
+            v-html="icon"
+            class="shrink-0 text-gray-400 [&>svg]:size-6 transition duration-75 group-hover:text-brand-500"
+            aria-hidden="true"
+        ></div>
+
+        <div class="mt-0.5 grid flex-1 gap-1 min-w-0">
+            <span class="text-sm font-medium text-gray-950">{{ name }}</span>
+            <p class="overflow-hidden text-sm text-pretty break-words text-gray-500">
+                {{ description }}
+            </p>
+        </div>
+
+        <ChevronRightIcon
+            class="shrink-0 size-5 self-center text-gray-400 opacity-0 transition-all group-hover:translate-x-1 group-hover:opacity-100"
+        />
+    </router-link>
+</template>

--- a/resources/js/components/portal/home/HelpCenter.vue
+++ b/resources/js/components/portal/home/HelpCenter.vue
@@ -1,10 +1,10 @@
 <!--
 <COPYRIGHT>
 
-    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
 
-    Advising App® is licensed under the Elastic License 2.0. For more details,
-    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
 
     Notice:
 
@@ -15,14 +15,14 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
-    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS® and Advising App® are registered trademarks of
-      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
       vigorously.
     - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS Inc.
+      Software as a Service (SaaS) by Canyon GBS LLC.
     - Use of this software implies agreement to the license terms and conditions as stated
       in the Elastic License 2.0.
 

--- a/resources/js/components/portal/home/HelpCenter.vue
+++ b/resources/js/components/portal/home/HelpCenter.vue
@@ -1,0 +1,61 @@
+<!--
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+-->
+<script setup>
+    import CategoryCard from './CategoryCard.vue';
+    import Subheading from './Subheading.vue';
+
+    defineProps({
+        categories: {
+            type: Object,
+            required: true,
+        },
+    });
+</script>
+
+<template>
+    <div class="flex flex-col gap-4">
+        <Subheading title="Article Categories" />
+
+        <div class="grid gap-3 md:grid-cols-2">
+            <CategoryCard
+                v-for="category in categories"
+                :key="category.id"
+                :to="{ name: 'view-category', params: { categoryId: category.id } }"
+                :icon="category.icon"
+                :name="category.name"
+                :description="category.description"
+            />
+        </div>
+    </div>
+</template>

--- a/resources/js/components/portal/home/HeroSearch.vue
+++ b/resources/js/components/portal/home/HeroSearch.vue
@@ -1,10 +1,10 @@
 <!--
 <COPYRIGHT>
 
-    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
 
-    Advising App® is licensed under the Elastic License 2.0. For more details,
-    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
 
     Notice:
 
@@ -15,14 +15,14 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
-    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS® and Advising App® are registered trademarks of
-      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
       vigorously.
     - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS Inc.
+      Software as a Service (SaaS) by Canyon GBS LLC.
     - Use of this software implies agreement to the license terms and conditions as stated
       in the Elastic License 2.0.
 

--- a/resources/js/components/portal/home/HeroSearch.vue
+++ b/resources/js/components/portal/home/HeroSearch.vue
@@ -1,0 +1,94 @@
+<!--
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+-->
+<script setup>
+    import { Bars3Icon, MagnifyingGlassIcon } from '@heroicons/vue/24/outline';
+    import { computed, defineEmits, defineProps } from 'vue';
+
+    const props = defineProps({
+        modelValue: {
+            type: [String, null],
+            default: null,
+        },
+    });
+
+    const emit = defineEmits(['update:modelValue', 'sidebarOpened']);
+
+    const searchQuery = computed({
+        get() {
+            return props.modelValue;
+        },
+        set(value) {
+            emit('update:modelValue', value);
+        },
+    });
+</script>
+
+<template>
+    <div class="sticky top-0 z-40 bg-gray-50 lg:hidden">
+        <button class="w-full p-3" type="button" @click="emit('sidebarOpened')">
+            <span class="sr-only">Open sidebar</span>
+
+            <Bars3Icon class="h-6 w-6 text-gray-900"></Bars3Icon>
+        </button>
+    </div>
+
+    <div
+        class="bg-[linear-gradient(to_right_bottom,rgba(var(--primary-500),1),rgba(var(--primary-800),1))] w-full px-6"
+    >
+        <div class="max-w-screen-xl flex flex-col gap-y-6 mx-auto py-8">
+            <div class="flex flex-col gap-y-1 text-left">
+                <h3 class="text-3xl font-semibold text-white">Need help?</h3>
+                <p class="text-primary-100">Search our resource hub for advice and answers</p>
+            </div>
+
+            <form action="#" method="GET">
+                <label for="search" class="sr-only">Search</label>
+
+                <div class="relative rounded">
+                    <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
+                        <MagnifyingGlassIcon class="h-5 w-5 text-gray-400" aria-hidden="true" />
+                    </div>
+
+                    <input
+                        id="search"
+                        v-model="searchQuery"
+                        type="search"
+                        placeholder="Search for articles and categories"
+                        class="block w-full rounded border-0 py-3 pl-12 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-primary-200 sm:text-sm sm:leading-6"
+                    />
+                </div>
+            </form>
+        </div>
+    </div>
+</template>

--- a/resources/js/components/portal/home/SearchLoading.vue
+++ b/resources/js/components/portal/home/SearchLoading.vue
@@ -1,10 +1,10 @@
 <!--
 <COPYRIGHT>
 
-    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
 
-    Advising App® is licensed under the Elastic License 2.0. For more details,
-    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
 
     Notice:
 
@@ -15,14 +15,14 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
-    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS® and Advising App® are registered trademarks of
-      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
       vigorously.
     - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS Inc.
+      Software as a Service (SaaS) by Canyon GBS LLC.
     - Use of this software implies agreement to the license terms and conditions as stated
       in the Elastic License 2.0.
 

--- a/resources/js/components/portal/home/SearchLoading.vue
+++ b/resources/js/components/portal/home/SearchLoading.vue
@@ -1,0 +1,40 @@
+<!--
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+-->
+<script setup>
+    import LoadingSpinner from '../LoadingSpinner.vue';
+</script>
+
+<template>
+    <LoadingSpinner label="Searching Resource Hub..." />
+</template>

--- a/resources/js/components/portal/home/SearchLoading.vue
+++ b/resources/js/components/portal/home/SearchLoading.vue
@@ -15,7 +15,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
@@ -32,7 +32,7 @@
 </COPYRIGHT>
 -->
 <script setup>
-    import LoadingSpinner from '../LoadingSpinner.vue';
+    import LoadingSpinner from '../../LoadingSpinner.vue';
 </script>
 
 <template>

--- a/resources/js/components/portal/home/SearchLoading.vue
+++ b/resources/js/components/portal/home/SearchLoading.vue
@@ -15,7 +15,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/resources/js/components/portal/home/SearchResults.vue
+++ b/resources/js/components/portal/home/SearchResults.vue
@@ -1,10 +1,10 @@
 <!--
 <COPYRIGHT>
 
-    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
 
-    Advising App® is licensed under the Elastic License 2.0. For more details,
-    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
 
     Notice:
 
@@ -15,14 +15,14 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
-    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS® and Advising App® are registered trademarks of
-      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
       vigorously.
     - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS Inc.
+      Software as a Service (SaaS) by Canyon GBS LLC.
     - Use of this software implies agreement to the license terms and conditions as stated
       in the Elastic License 2.0.
 

--- a/resources/js/components/portal/home/SearchResults.vue
+++ b/resources/js/components/portal/home/SearchResults.vue
@@ -1,0 +1,130 @@
+<!--
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+-->
+<script setup>
+    import SearchLoading from './SearchLoading.vue';
+    import { ChevronRightIcon, XMarkIcon } from '@heroicons/vue/20/solid';
+    import { defineProps } from 'vue';
+
+    defineProps({
+        searchQuery: {
+            type: String,
+            required: true,
+        },
+        searchResults: {
+            type: Object,
+            required: true,
+        },
+        loadingResults: {
+            type: Boolean,
+            required: true,
+        },
+    });
+</script>
+
+<template>
+    <div v-if="loadingResults">
+        <SearchLoading />
+    </div>
+
+    <div v-if="!loadingResults && searchResults?.data" class="flex flex-col gap-6">
+        <h3 class="text-2xl font-bold text-primary-950">
+            Search results: <span class="font-normal">{{ searchQuery }}</span>
+        </h3>
+
+        <div
+            class="flex flex-col divide-y divide-gray-200 ring-1 ring-black/5 shadow-xs px-3 pt-3 pb-1 rounded bg-white"
+        >
+            <h4 class="text-lg font-semibold text-gray-800 px-3 pt-1 pb-3">
+                Articles ({{ searchResults.data.articles.length }})
+            </h4>
+
+            <div v-if="searchResults.data.articles.length > 0">
+                <ul role="list" class="divide-y divide-gray-200">
+                    <li v-for="article in searchResults.data.articles" :key="article.id">
+                        <router-link
+                            :to="{
+                                name: 'view-article',
+                                params: { categoryId: article.categoryId, articleId: article.id },
+                            }"
+                            class="group p-3 flex items-start text-sm font-medium text-gray-700"
+                        >
+                            <h5>
+                                {{ article.name }}
+                            </h5>
+
+                            <ChevronRightIcon
+                                class="opacity-0 h-5 w-5 text-primary-600 transition-all group-hover:translate-x-2 group-hover:opacity-100"
+                            />
+                        </router-link>
+                    </li>
+                </ul>
+            </div>
+            <div v-else class="p-3 flex items-start gap-2">
+                <XMarkIcon class="h-5 w-5 text-gray-400" />
+
+                <p class="text-gray-600 text-sm font-medium">No articles found that match this search.</p>
+            </div>
+        </div>
+
+        <div
+            class="flex flex-col divide-y divide-gray-200 ring-1 ring-black/5 shadow-xs px-3 pt-3 pb-1 rounded bg-white"
+        >
+            <h4 class="text-lg font-semibold text-gray-800 px-3 pt-1 pb-3">Categories</h4>
+
+            <div v-if="searchResults.data.categories.length > 0">
+                <ul role="list" class="divide-y divide-gray-200">
+                    <li v-for="category in searchResults.data.categories" :key="category.id">
+                        <router-link
+                            :to="{ name: 'view-category', params: { categoryId: category.id } }"
+                            class="group p-3 flex items-start text-sm font-medium text-gray-700"
+                        >
+                            <h5>
+                                {{ category.name }}
+                            </h5>
+
+                            <ChevronRightIcon
+                                class="opacity-0 h-5 w-5 text-primary-600 transition-all group-hover:translate-x-2 group-hover:opacity-100"
+                            />
+                        </router-link>
+                    </li>
+                </ul>
+            </div>
+            <div v-else class="p-3 flex items-start gap-2">
+                <XMarkIcon class="h-5 w-5 text-gray-400" />
+
+                <p class="text-gray-600 text-sm font-medium">No categories found that match this search.</p>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/components/portal/home/Subheading.vue
+++ b/resources/js/components/portal/home/Subheading.vue
@@ -1,10 +1,10 @@
 <!--
 <COPYRIGHT>
 
-    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
 
-    Advising App® is licensed under the Elastic License 2.0. For more details,
-    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
 
     Notice:
 
@@ -15,14 +15,14 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
-    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS® and Advising App® are registered trademarks of
-      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
       vigorously.
     - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS Inc.
+      Software as a Service (SaaS) by Canyon GBS LLC.
     - Use of this software implies agreement to the license terms and conditions as stated
       in the Elastic License 2.0.
 

--- a/resources/js/components/portal/home/Subheading.vue
+++ b/resources/js/components/portal/home/Subheading.vue
@@ -1,0 +1,48 @@
+<!--
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+-->
+<script setup>
+    defineProps({
+        title: {
+            type: String,
+            default: '',
+        },
+    });
+</script>
+
+<template>
+    <h2 class="text-xl font-medium text-gray-950">
+        <template v-if="$slots.default"><slot /></template>
+        <template v-else>{{ title }}</template>
+    </h2>
+</template>


### PR DESCRIPTION
## Summary

Adds shared Vue components for the portal homepage, to be consumed by both Advising App and Aiding App resource-hub portals.

## Components Added

All components are in `resources/js/components/portal/home/`:

- **CategoryCard.vue** — link card displaying a knowledge-base category (icon, name, description, animated chevron)
- **HelpCenter.vue** — article categories grid, composes `CategoryCard` + `Subheading`
- **HeroSearch.vue** — hero banner section with gradient background and search input
- **SearchLoading.vue** — search loading state, delegates to the existing `LoadingSpinner`
- **SearchResults.vue** — search results panel showing matched articles and categories
- **Subheading.vue** — reusable `h2` section heading (accepts `title` prop or default slot)

## Usage

Import via the `@common` alias already configured in portal `vite.config.js` files:

```js
import HelpCenter from '@common/portal/home/HelpCenter.vue';
import HeroSearch  from '@common/portal/home/HeroSearch.vue';
import SearchResults from '@common/portal/home/SearchResults.vue';
```

## Related

- Advising App PR: ADVAPP-2763 (portal homepage implementation)