### PR TITLE
[OLYMPUS-1470]: Convert the settings class property defaults test into a common PHPStan rule

### DIFF
--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -55,6 +55,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: CanyonGBS\Common\Rules\SettingsPropertiesMustHaveDefaults\SettingsPropertiesMustHaveDefaultsRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: CanyonGBS\Common\Rules\ShouldBeUniqueJobMustDefineUniqueFor\ShouldBeUniqueJobMustDefineUniqueForRule
         tags:
             - phpstan.rules.rule

--- a/src/Rules/SettingsPropertiesMustHaveDefaults/SettingsPropertiesMustHaveDefaultsRule.php
+++ b/src/Rules/SettingsPropertiesMustHaveDefaults/SettingsPropertiesMustHaveDefaultsRule.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/src/Rules/SettingsPropertiesMustHaveDefaults/SettingsPropertiesMustHaveDefaultsRule.php
+++ b/src/Rules/SettingsPropertiesMustHaveDefaults/SettingsPropertiesMustHaveDefaultsRule.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+declare(strict_types = 1);
+
+namespace CanyonGBS\Common\Rules\SettingsPropertiesMustHaveDefaults;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Enforces that all properties declared in Spatie Settings classes have a PHP default value.
+ *
+ * Spatie's LoadingSettings event relies on PHP reflection to populate settings properties
+ * that have not yet been persisted to the database. If a property has no declared default,
+ * reflection returns null regardless of the declared type, causing silent type errors at runtime.
+ *
+ * @implements Rule<Property>
+ */
+class SettingsPropertiesMustHaveDefaultsRule implements Rule
+{
+    public const string ERROR_MESSAGE = 'Property $%s in a Spatie Settings class must have a default value. Properties without defaults cause silent type errors when the value has not yet been saved to the database.';
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return Property::class;
+    }
+
+    /**
+     * @param Property $node
+     *
+     * @return array<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return [];
+        }
+
+        if (
+            ! $classReflection->isSubclassOf('Spatie\LaravelSettings\Settings')
+            && $classReflection->getName() !== 'Spatie\LaravelSettings\Settings'
+        ) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($node->props as $prop) {
+            if ($prop->default !== null) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $prop->name->name))
+                ->identifier('Common.settingsPropertyMissingDefault')
+                ->build();
+        }
+
+        return $errors;
+    }
+}

--- a/src/Rules/SettingsPropertiesMustHaveDefaults/SettingsPropertiesMustHaveDefaultsRule.php
+++ b/src/Rules/SettingsPropertiesMustHaveDefaults/SettingsPropertiesMustHaveDefaultsRule.php
@@ -79,10 +79,7 @@ class SettingsPropertiesMustHaveDefaultsRule implements Rule
             return [];
         }
 
-        if (
-            ! $classReflection->isSubclassOf('Spatie\LaravelSettings\Settings')
-            && $classReflection->getName() !== 'Spatie\LaravelSettings\Settings'
-        ) {
+        if (! $classReflection->isSubclassOf('Spatie\LaravelSettings\Settings')) {
             return [];
         }
 

--- a/tests/PHPStan/Configs/settings-properties-must-have-defaults.neon
+++ b/tests/PHPStan/Configs/settings-properties-must-have-defaults.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\SettingsPropertiesMustHaveDefaults\SettingsPropertiesMustHaveDefaultsRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Fixtures/NonSettingsWithoutDefaultsFixture.php
+++ b/tests/PHPStan/Fixtures/NonSettingsWithoutDefaultsFixture.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/tests/PHPStan/Fixtures/NonSettingsWithoutDefaultsFixture.php
+++ b/tests/PHPStan/Fixtures/NonSettingsWithoutDefaultsFixture.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+class NonSettingsClassWithoutDefaults
+{
+    public string $name;
+
+    public ?string $optionalValue;
+}

--- a/tests/PHPStan/Fixtures/SettingsWithDefaultsFixture.php
+++ b/tests/PHPStan/Fixtures/SettingsWithDefaultsFixture.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/tests/PHPStan/Fixtures/SettingsWithDefaultsFixture.php
+++ b/tests/PHPStan/Fixtures/SettingsWithDefaultsFixture.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace Spatie\LaravelSettings {
+    abstract class Settings
+    {
+        abstract public static function group(): string;
+    }
+}
+
+namespace {
+    use Spatie\LaravelSettings\Settings;
+
+    class SettingsWithDefaults extends Settings
+    {
+        public string $name = 'default';
+
+        public ?string $optionalValue = null;
+
+        public bool $isEnabled = false;
+
+        public int $count = 0;
+
+        public static function group(): string
+        {
+            return 'test';
+        }
+    }
+}

--- a/tests/PHPStan/Fixtures/SettingsWithoutDefaultsFixture.php
+++ b/tests/PHPStan/Fixtures/SettingsWithoutDefaultsFixture.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/tests/PHPStan/Fixtures/SettingsWithoutDefaultsFixture.php
+++ b/tests/PHPStan/Fixtures/SettingsWithoutDefaultsFixture.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace Spatie\LaravelSettings {
+    abstract class Settings
+    {
+        abstract public static function group(): string;
+    }
+}
+
+namespace {
+    use Spatie\LaravelSettings\Settings;
+
+    class SettingsWithoutDefaults extends Settings
+    {
+        public string $name;
+
+        public ?string $optionalValue;
+
+        public static function group(): string
+        {
+            return 'test';
+        }
+    }
+}

--- a/tests/PHPStan/SettingsPropertiesMustHaveDefaultsTest.php
+++ b/tests/PHPStan/SettingsPropertiesMustHaveDefaultsTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of

--- a/tests/PHPStan/SettingsPropertiesMustHaveDefaultsTest.php
+++ b/tests/PHPStan/SettingsPropertiesMustHaveDefaultsTest.php
@@ -68,7 +68,7 @@ function runPhpStanOnSettingsFixture(string $filePath): array
 {
     $basePath = dirname(__DIR__, 2);
     $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
-    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/settings-properties-must-have-defaults.neon');
     $file = escapeshellarg($filePath);
 
     $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";

--- a/tests/PHPStan/SettingsPropertiesMustHaveDefaultsTest.php
+++ b/tests/PHPStan/SettingsPropertiesMustHaveDefaultsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('does not report Settings class properties that all have default values', function () {
+    $result = runPhpStanOnSettingsFixture('tests/PHPStan/Fixtures/SettingsWithDefaultsFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report errors when all Settings properties have defaults.\nOutput: {$result['output']}");
+});
+
+it('reports Settings class properties that are missing default values', function () {
+    $result = runPhpStanOnSettingsFixture('tests/PHPStan/Fixtures/SettingsWithoutDefaultsFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.settingsPropertyMissingDefault');
+});
+
+it('reports each property individually that is missing a default value', function () {
+    $result = runPhpStanOnSettingsFixture('tests/PHPStan/Fixtures/SettingsWithoutDefaultsFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('$name');
+    expect($result['output'])->toContain('$optionalValue');
+});
+
+it('does not report non-Settings class properties that are missing default values', function () {
+    $result = runPhpStanOnSettingsFixture('tests/PHPStan/Fixtures/NonSettingsWithoutDefaultsFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report missing defaults on non-Settings classes.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnSettingsFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/phpstan-test.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

-

### Technical Description

> Enforces that all properties in Spatie Settings subclasses declare a
PHP default value. Without a default, PHP reflection returns null
regardless of the declared type, causing silent type errors at runtime
when the value has not yet been persisted.

- Add SettingsPropertiesMustHaveDefaultsRule (Property node, isSubclassOf guard)
- Register rule in phpstan-extension.neon
- Add fixtures: SettingsWithDefaults, SettingsWithoutDefaults, NonSettingsWithoutDefaults
- Add SettingsPropertiesMustHaveDefaultsTest

### Any deployment steps required?

> NO

### Are any Feature Flags and/or Data Migrations that can eventually be removed added?

> NO

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/common/blob/main/README.md#contributing).
