### PR TITLE
[ADVAPP-2813]: Update forms, events, and admissions behavior when submissions have occurred

### DIFF
--- a/docs/how-tos/archiving.md
+++ b/docs/how-tos/archiving.md
@@ -147,6 +147,47 @@ It excludes:
 
 - Archived records that are **not "used"**.
 
+### Checking whether a single record is used
+
+The `used()` method filters queries. Its record-level counterpart is an optional `isUsed()` method, which reports whether an individual record is still referenced:
+
+```php
+class ProjectType extends Model
+{
+    use CanBeArchived;
+
+    public function used(Builder $query): void
+    {
+        $query->whereHas('projects');
+    }
+
+    public function isUsed(): bool
+    {
+        return (bool) ($this->projects_exists ??= $this->projects()->exists());
+    }
+}
+```
+
+The two methods should agree on what "used" means. Defining `isUsed()` changes the behavior of the `ArchiveAction` Filament component, which deletes unused records instead of archiving them ([see below](#filament-archive-action)).
+
+#### Keeping `isUsed()` efficient
+
+`isUsed()` may be called several times per request, so implement it with the pattern above instead of querying the relationship directly. `$this->projects_exists` is the attribute that Eloquent's `withExists('projects')` populates: when the record was retrieved with `withExists()`, the check reads the eager-loaded value and runs no query at all. Otherwise, the first call runs a single `exists` query and stores the result in the same attribute, so repeated calls never query again.
+
+In a table context, where `isUsed()` may be evaluated for every row, always eager-load the existence check with `modifyQueryUsing()` to avoid one query per record:
+
+```php
+use Illuminate\Database\Eloquent\Builder;
+
+$table->modifyQueryUsing(
+    fn (Builder $query) => $query->withExists('projects'),
+)
+```
+
+This can be combined with other query changes, such as `withoutArchived()`.
+
+One caveat of the memoizing pattern: when the value is computed lazily (without `withExists()`), the result is stored as a "dirty" attribute on the model. Avoid calling `save()` on the same model instance afterwards, as the attribute does not correspond to a real database column.
+
 ---
 
 ## Model events
@@ -177,7 +218,7 @@ Project::unarchived(function (Project $project) {
 
 ## Authorization
 
-Define an `archive` method on your model's policy. The `ArchiveAction` Filament component calls `can('archive', $record)` to determine if the action should be available.
+The `ArchiveAction` Filament component calls `can('delete', $record)` to determine if the action should be available, so define a `delete` method on your model's policy. The same ability is checked whether the action archives or deletes the record -- archiving is a soft alternative to deletion, so it is governed by the same permission.
 
 ```php
 use App\Models\Project;
@@ -186,17 +227,11 @@ use Illuminate\Auth\Access\Response;
 
 class ProjectPolicy
 {
-    public function archive(User $user, Project $project): Response
+    public function delete(User $user, Project $project): Response
     {
-        // Example: only allow archiving if the project has associated data
-        // that would be lost by deletion.
-        if (! $project->tasks()->exists()) {
-            return Response::deny('Delete this project instead of archiving it.');
-        }
-
         return $user->can('projects.delete')
             ? Response::allow()
-            : Response::deny('You do not have permission to archive this project.');
+            : Response::deny('You do not have permission to delete this project.');
     }
 }
 ```
@@ -228,8 +263,28 @@ class EditProject extends EditRecord
 The action:
 
 - Is hidden when the record is already archived.
-- Authorizes via the policy's `archive` method.
+- Authorizes via the policy's `delete` method.
 - Redirects to the resource's index page on success.
+
+### Deleting unused records instead of archiving
+
+Archiving exists to preserve records that are still referenced elsewhere. If a record is not referenced by anything, there is nothing to preserve, and it can safely be deleted outright.
+
+If the model defines an optional `isUsed()` method ([see above](#checking-whether-a-single-record-is-used)), `ArchiveAction` becomes a dual-mode action:
+
+- **`isUsed()` returns `true`** -- the record is still referenced, so the action looks and behaves exactly as described above: it archives the record.
+- **`isUsed()` returns `false`** -- the record is unreferenced, so the action looks and behaves like Filament's `DeleteAction` instead: it is labelled "Delete" with a `danger` color and trash icon, calls `$record->delete()`, and is hidden when the record is soft-deleted (rather than when it is archived).
+
+If the model does not define `isUsed()`, the action always archives.
+
+Closures passed to the action can check which mode applies to the current record by calling `shouldDeleteInsteadOfArchive()` on the action:
+
+```php
+ArchiveAction::make()
+    ->modalDescription(fn (ArchiveAction $action): ?string => $action->shouldDeleteInsteadOfArchive()
+        ? 'This record is not in use, so it will be permanently deleted.'
+        : null)
+```
 
 ### Custom authorization or redirect
 
@@ -237,9 +292,83 @@ The default `authorize()` and `successRedirectUrl()` callbacks expect the action
 
 ```php
 ArchiveAction::make()
-    ->authorize(fn (Model $record): bool => Gate::allows('archive', $record))
+    ->authorize(fn (Model $record): bool => Gate::allows('delete', $record))
     ->successRedirectUrl('/projects');
 ```
+
+### Customizing the operation
+
+Like Filament's `DeleteAction`, the archive/delete operation itself can be replaced with `using()`. Return `true` on success or `false` to report a failure:
+
+```php
+ArchiveAction::make()
+    ->using(function (Model $record, ArchiveAction $action): bool {
+        if ($action->shouldDeleteInsteadOfArchive($record)) {
+            return (bool) $record->delete();
+        }
+
+        return $record->archive();
+    })
+```
+
+---
+
+## Filament: bulk archive action
+
+`ArchiveBulkAction` is a table bulk action that processes all selected records:
+
+```php
+use CanyonGBS\Common\Filament\Actions\ArchiveBulkAction;
+
+public static function table(Table $table): Table
+{
+    return $table
+        ->toolbarActions([
+            ArchiveBulkAction::make(),
+        ]);
+}
+```
+
+Like the single-record `ArchiveAction` uses `isUsed()`, the bulk action decides between archiving and deleting -- but at the query level, using the model's `used()` scope:
+
+- If the model defines `used()`, selected records that are "used" are archived, and the rest are permanently deleted. The confirmation modal warns the user about this.
+- If the model does not define `used()`, every selected record is archived.
+- If the model does not use the `CanBeArchived` trait, an exception is thrown.
+
+The notification sent when the action finishes counts each operation separately -- for example, "5 archived, 3 deleted". If some records could not be processed, failure messages are appended below the counts.
+
+Closures passed to the action can check whether unused records will be deleted by calling `shouldDeleteUnusedRecords()` on the action.
+
+### Processing modes
+
+By default, records are fetched and processed one at a time, so `archiving`/`deleting` model events fire for each record. An operation cancelled by an event listener counts as a failure in the final notification. To determine which records to archive, the `used()` scope is applied to the selection in a single query up front, so the split does not cost a query per record.
+
+To avoid loading a large selection into memory at once, records can be fetched in chunks:
+
+```php
+ArchiveBulkAction::make()
+    ->chunkSelectedRecords(100)
+```
+
+For the fastest option, `fetchSelectedRecords(false)` switches to two bulk statements (one `UPDATE`, one `DELETE`) with no model hydration at all, but model events do not fire, and per-record failure reporting is unavailable:
+
+```php
+ArchiveBulkAction::make()
+    ->fetchSelectedRecords(false)
+```
+
+### Bulk authorization
+
+By default, the action is authorized with the policy's `deleteAny` method -- one check for the whole selection, consistent with Filament's `DeleteBulkAction`.
+
+To also check the `delete` policy method for each individual record, use `authorizeIndividualRecords()`:
+
+```php
+ArchiveBulkAction::make()
+    ->authorizeIndividualRecords('delete')
+```
+
+Records that fail the check are skipped, and the final notification reports how many were skipped alongside the archived/deleted counts. Individual record authorization only applies in the default (fetched) processing mode.
 
 ---
 

--- a/src/Filament/Actions/ArchiveAction.php
+++ b/src/Filament/Actions/ArchiveAction.php
@@ -38,59 +38,135 @@ namespace CanyonGBS\Common\Filament\Actions;
 
 use Exception;
 use Filament\Actions\Action;
+use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Resources\Pages\ViewRecord;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
-class ArchiveAction
+class ArchiveAction extends Action
 {
-    public static function make(): Action
+    use CanCustomizeProcess;
+
+    protected function setUp(): void
     {
-        return Action::make('archive')
-            ->label('Archive')
-            ->modalHeading(fn (Action $action): string => "Archive {$action->getRecordTitle()}")
-            ->modalSubmitActionLabel('Archive')
-            ->successNotificationTitle('Archived')
-            ->defaultColor('warning')
-            ->groupedIcon('heroicon-m-archive-box')
-            ->modalIcon('heroicon-o-archive-box')
-            ->hidden(static function (Model $record): bool {
-                if (! method_exists($record, 'isArchived')) {
-                    throw new Exception('The [ArchiveAction] requires the model to use the [CanBeArchived] trait.');
+        parent::setUp();
+
+        $this->label(fn (Model $record): string => $this->shouldDeleteInsteadOfArchive($record) ? 'Delete' : 'Archive');
+
+        $this->modalHeading(fn (Model $record): string => ($this->shouldDeleteInsteadOfArchive($record) ? 'Delete' : 'Archive') . " {$this->getRecordTitle()}");
+
+        $this->modalSubmitActionLabel(fn (Model $record): string => $this->shouldDeleteInsteadOfArchive($record) ? 'Delete' : 'Archive');
+
+        $this->successNotificationTitle(function (?Model $record): string {
+            // The record is no longer resolvable once it has been deleted,
+            // which only happens after a successful deletion.
+            if (! $record instanceof Model) {
+                return 'Deleted';
+            }
+
+            return $this->shouldDeleteInsteadOfArchive($record) ? 'Deleted' : 'Archived';
+        });
+
+        $this->defaultColor(fn (Model $record): string => $this->shouldDeleteInsteadOfArchive($record) ? 'danger' : 'warning');
+
+        $this->groupedIcon(fn (Model $record): Heroicon => $this->shouldDeleteInsteadOfArchive($record) ? Heroicon::Trash : Heroicon::ArchiveBox);
+
+        $this->modalIcon(fn (Model $record): Heroicon => $this->shouldDeleteInsteadOfArchive($record) ? Heroicon::OutlinedTrash : Heroicon::OutlinedArchiveBox);
+
+        $this->hidden(function (Model $record): bool {
+            if ($this->shouldDeleteInsteadOfArchive($record)) {
+                if (! method_exists($record, 'trashed')) {
+                    return false;
                 }
 
-                return $record->isArchived();
-            })
-            ->requiresConfirmation()
-            ->action(function (Action $action, Model $record): void {
+                return $record->trashed();
+            }
+
+            if (! method_exists($record, 'isArchived')) {
+                throw new Exception('The [ArchiveAction] requires the model to use the [CanBeArchived] trait.');
+            }
+
+            return $record->isArchived();
+        });
+
+        $this->requiresConfirmation();
+
+        $this->action(function (): void {
+            $result = $this->process(function (Model $record): bool {
+                if ($this->shouldDeleteInsteadOfArchive($record)) {
+                    return (bool) $record->delete();
+                }
+
                 if (! method_exists($record, 'archive')) {
                     throw new Exception('The [ArchiveAction] requires the model to use the [CanBeArchived] trait.');
                 }
 
-                $result = $record->archive();
-
-                if (! $result) {
-                    $action->failure();
-
-                    return;
-                }
-
-                $action->success();
-            })
-            ->authorize(function (Model $record, Component $livewire): bool {
-                if ((! $livewire instanceof EditRecord) && (! $livewire instanceof ViewRecord)) {
-                    throw new Exception('Unsupported Livewire component for [ArchiveAction] authorization. It must be used within [EditRecord] or [ViewRecord], or a custom [authorize()] function must be used.');
-                }
-
-                return $livewire::getResource()::can('archive', $record);
-            })
-            ->successRedirectUrl(function (Component $livewire): string {
-                if ((! $livewire instanceof EditRecord) && (! $livewire instanceof ViewRecord)) {
-                    throw new Exception('Unsupported Livewire component for [ArchiveAction] redirect. It must be used within [EditRecord] or [ViewRecord], or a custom [successRedirectUrl()] function must be used.');
-                }
-
-                return $livewire::getResource()::getUrl('index');
+                return $record->archive();
             });
+
+            if (! $result) {
+                $this->failure();
+
+                return;
+            }
+
+            $this->success();
+        });
+
+        $this->authorize(function (Model $record, Component $livewire): bool {
+            if ((! $livewire instanceof EditRecord) && (! $livewire instanceof ViewRecord)) {
+                throw new Exception('Unsupported Livewire component for [ArchiveAction] authorization. It must be used within [EditRecord] or [ViewRecord], or a custom [authorize()] function must be used.');
+            }
+
+            if ((! $this->shouldDeleteInsteadOfArchive($record)) && $this->hasArchivePolicyMethod($record)) {
+                return $livewire::getResource()::can('archive', $record);
+            }
+
+            return $livewire::getResource()::can('delete', $record);
+        });
+
+        $this->successRedirectUrl(function (Component $livewire): string {
+            if ((! $livewire instanceof EditRecord) && (! $livewire instanceof ViewRecord)) {
+                throw new Exception('Unsupported Livewire component for [ArchiveAction] redirect. It must be used within [EditRecord] or [ViewRecord], or a custom [successRedirectUrl()] function must be used.');
+            }
+
+            return $livewire::getResource()::getUrl('index');
+        });
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'archive';
+    }
+
+    /**
+     * Archiving exists to preserve records that are still referenced elsewhere.
+     * A model may define an optional `isUsed()` method to report whether the
+     * individual record is still referenced, in which case unreferenced records
+     * are safe to delete outright instead of being archived.
+     */
+    public function shouldDeleteInsteadOfArchive(?Model $record = null): bool
+    {
+        $record ??= $this->getRecord();
+
+        if (! $record instanceof Model) {
+            return false;
+        }
+
+        if (! method_exists($record, 'isUsed')) {
+            return false;
+        }
+
+        return ! $record->isUsed();
+    }
+
+    protected function hasArchivePolicyMethod(Model $record): bool
+    {
+        $policy = Gate::getPolicyFor($record::class);
+
+        return filled($policy) && method_exists($policy, 'archive');
     }
 }

--- a/src/Filament/Actions/ArchiveBulkAction.php
+++ b/src/Filament/Actions/ArchiveBulkAction.php
@@ -63,7 +63,7 @@ class ArchiveBulkAction extends BulkAction
     {
         parent::setUp();
 
-        $this->label('Archive');
+        $this->label(fn (): string => $this->shouldDeleteUnusedRecords() ? 'Archive / Delete' : 'Archive');
 
         $this->modalHeading(fn (): string => "Archive {$this->getTitleCasePluralModelLabel()}");
 

--- a/src/Filament/Actions/ArchiveBulkAction.php
+++ b/src/Filament/Actions/ArchiveBulkAction.php
@@ -1,0 +1,259 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Filament\Actions;
+
+use Exception;
+use Filament\Actions\BulkAction;
+use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Auth\Access\Response;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
+use Throwable;
+
+class ArchiveBulkAction extends BulkAction
+{
+    use CanCustomizeProcess;
+
+    protected int $archivedCount = 0;
+
+    protected int $deletedCount = 0;
+
+    /**
+     * @var array<array-key, int> | null
+     */
+    protected ?array $usedKeys = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('Archive');
+
+        $this->modalHeading(fn (): string => "Archive {$this->getTitleCasePluralModelLabel()}");
+
+        $this->modalSubmitActionLabel('Archive');
+
+        $this->modalDescription(function (): ?string {
+            if (! $this->shouldDeleteUnusedRecords()) {
+                return null;
+            }
+
+            return 'Records that are no longer in use will be permanently deleted instead of archived.';
+        });
+
+        $this->successNotificationTitle(fn (): string => $this->getCountsNotificationTitle());
+
+        $this->failureNotificationTitle(fn (): string => $this->getCountsNotificationTitle());
+
+        $this->missingBulkAuthorizationFailureNotificationMessage(fn (int $failureCount): string => ($failureCount === 1)
+            ? '1 record could not be processed because you are not authorized to delete it.'
+            : "{$failureCount} records could not be processed because you are not authorized to delete them.");
+
+        $this->missingBulkProcessingFailureNotificationMessage(fn (int $failureCount): string => ($failureCount === 1)
+            ? '1 record failed to process.'
+            : "{$failureCount} records failed to process.");
+
+        $this->authorize('deleteAny');
+
+        $this->defaultColor('warning');
+
+        $this->icon(Heroicon::ArchiveBox);
+
+        $this->requiresConfirmation();
+
+        $this->modalIcon(Heroicon::OutlinedArchiveBox);
+
+        $this->action(function (): void {
+            $this->archivedCount = 0;
+            $this->deletedCount = 0;
+            $this->usedKeys = null;
+
+            $this->process(static function (ArchiveBulkAction $action): void {
+                $model = $action->getModel();
+
+                if (! method_exists($model, 'archive')) {
+                    throw new Exception('The [ArchiveBulkAction] requires the model to use the [CanBeArchived] trait.');
+                }
+
+                $modelInstance = new $model();
+
+                $shouldDeleteUnused = $action->shouldDeleteUnusedRecords();
+
+                if (! $action->shouldFetchSelectedRecords()) {
+                    // Individual record authorization only applies when records are
+                    // fetched, so only the selection counts are initialized here.
+                    $action->getSelectedRecords();
+
+                    try {
+                        $query = $action->getSelectedRecordsQuery();
+
+                        if ($shouldDeleteUnused) {
+                            $action->archivedCount = $query->clone()
+                                ->where(fn (Builder $query) => $modelInstance->used($query)) /** @phpstan-ignore method.notFound */
+                                ->archive(); /** @phpstan-ignore method.notFound */
+                            $action->deletedCount = $query->clone()
+                                ->whereNot(fn (Builder $query) => $modelInstance->used($query)) /** @phpstan-ignore method.notFound */
+                                ->delete();
+                        } else {
+                            $action->archivedCount = $query->archive(); /** @phpstan-ignore method.notFound */
+                        }
+
+                        $action->reportBulkProcessingSuccessfulRecordsCount($action->archivedCount + $action->deletedCount);
+                    } catch (Throwable $exception) {
+                        $action->reportCompleteBulkProcessingFailure();
+
+                        report($exception);
+                    }
+
+                    return;
+                }
+
+                // The partition is computed before the records are individually
+                // authorized, as it determines which policy method applies to
+                // each record.
+                $action->usedKeys = $shouldDeleteUnused
+                    ? $action->getSelectedRecordsQuery()
+                        ->where(fn (Builder $query) => $modelInstance->used($query)) /** @phpstan-ignore method.notFound */
+                        ->pluck($modelInstance->getQualifiedKeyName())
+                        ->flip()
+                        ->all()
+                    : null;
+
+                $records = $action->getIndividuallyAuthorizedSelectedRecords();
+
+                $isFirstException = true;
+
+                $records->each(static function (Model $record) use ($action, &$isFirstException): void {
+                    $shouldArchive = ($action->usedKeys === null) || array_key_exists($record->getKey(), $action->usedKeys);
+
+                    try {
+                        if ($shouldArchive) {
+                            $record->archive() /** @phpstan-ignore method.notFound */
+                                ? $action->archivedCount++
+                                : $action->reportBulkProcessingFailure();
+                        } else {
+                            $record->delete()
+                                ? $action->deletedCount++
+                                : $action->reportBulkProcessingFailure();
+                        }
+                    } catch (Throwable $exception) {
+                        $action->reportBulkProcessingFailure();
+
+                        if ($isFirstException) {
+                            // Only report the first exception to not flood error logs. Even if Filament
+                            // did not catch exceptions like this, only the first would be reported
+                            // as the rest of the process would be halted.
+                            report($exception);
+
+                            $isFirstException = false;
+                        }
+                    }
+                });
+            });
+        });
+
+        $this->deselectRecordsAfterCompletion();
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'archive';
+    }
+
+    /**
+     * Archiving exists to preserve records that are still referenced elsewhere.
+     * A model may define an optional `used()` scope to constrain a query to
+     * records that are still referenced, in which case unreferenced records
+     * are safe to delete outright instead of being archived.
+     */
+    public function shouldDeleteUnusedRecords(): bool
+    {
+        $model = $this->getModel();
+
+        return filled($model) && method_exists($model, 'used');
+    }
+
+    public function getIndividualRecordAuthorizationResponse(Model $record): Response
+    {
+        if (
+            ($this->authorizeIndividualRecords === 'delete')
+            && $this->isRecordPlannedToBeArchived($record)
+            && $this->hasArchivePolicyMethod($record)
+        ) {
+            return Gate::inspect('archive', [$record]);
+        }
+
+        return parent::getIndividualRecordAuthorizationResponse($record);
+    }
+
+    protected function isRecordPlannedToBeArchived(Model $record): bool
+    {
+        if (! $this->shouldDeleteUnusedRecords()) {
+            return true;
+        }
+
+        return array_key_exists($record->getKey(), $this->usedKeys ?? []);
+    }
+
+    protected function hasArchivePolicyMethod(Model $record): bool
+    {
+        $policy = Gate::getPolicyFor($record::class);
+
+        return filled($policy) && method_exists($policy, 'archive');
+    }
+
+    protected function getCountsNotificationTitle(): string
+    {
+        $parts = [];
+
+        if ($this->archivedCount) {
+            $parts[] = "{$this->archivedCount} archived";
+        }
+
+        if ($this->deletedCount) {
+            $parts[] = "{$this->deletedCount} deleted";
+        }
+
+        if ($parts === []) {
+            return 'No records were archived or deleted';
+        }
+
+        return implode(', ', $parts);
+    }
+}

--- a/tests/Filament/Actions/ArchiveActionTest.php
+++ b/tests/Filament/Actions/ArchiveActionTest.php
@@ -1,0 +1,362 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Support\Icons\Heroicon;
+use Livewire\Livewire;
+use Workbench\App\Filament\Resources\Articles\ArticleResource;
+use Workbench\App\Filament\Resources\Articles\Pages\EditArticle;
+use Workbench\App\Filament\Resources\Articles\Pages\ViewArticle;
+use Workbench\App\Filament\Resources\Attachments\Pages\EditAttachment;
+use Workbench\App\Filament\Resources\Projects\Pages\EditProject;
+use Workbench\App\Filament\Resources\Projects\Pages\ViewProject;
+use Workbench\App\Filament\Resources\Projects\ProjectResource;
+use Workbench\App\Filament\Resources\Tags\Pages\EditTag;
+use Workbench\App\Filament\Resources\Tasks\Pages\EditTask;
+use Workbench\App\Models\Article;
+use Workbench\App\Models\Attachment;
+use Workbench\App\Models\Project;
+use Workbench\App\Models\Review;
+use Workbench\App\Models\Tag;
+use Workbench\App\Models\Task;
+use Workbench\App\Models\User;
+use Workbench\App\Policies\ArticlePolicy;
+use Workbench\App\Policies\AttachmentPolicy;
+use Workbench\App\Policies\ProjectPolicy;
+use Workbench\App\Policies\TagPolicy;
+
+beforeEach(function () {
+    ProjectPolicy::reset();
+    ArticlePolicy::reset();
+    AttachmentPolicy::reset();
+    TagPolicy::reset();
+
+    Filament::setCurrentPanel('testing');
+
+    $this->actingAs(User::create(['name' => 'Ada', 'email' => 'ada@example.com']));
+});
+
+it('looks like an archive action when the model does not define `isUsed()`', function () {
+    $project = Project::factory()->create(['name' => 'Apollo']);
+
+    Livewire::test(EditProject::class, ['record' => $project->getRouteKey()])
+        ->assertActionHasLabel('archive', 'Archive')
+        ->assertActionHasColor('archive', 'warning')
+        ->assertActionExists('archive', fn (Action $action): bool => ((string) $action->getModalHeading()) === 'Archive Apollo')
+        ->assertActionExists('archive', fn (Action $action): bool => $action->getModalSubmitActionLabel() === 'Archive')
+        ->assertActionExists('archive', fn (Action $action): bool => $action->getModalIcon() === Heroicon::OutlinedArchiveBox)
+        ->assertActionExists('archive', fn (Action $action): bool => $action->getGroupedIcon() === Heroicon::ArchiveBox);
+});
+
+it('archives the record and redirects to the index page', function () {
+    $project = Project::factory()->create();
+
+    Livewire::test(EditProject::class, ['record' => $project->getRouteKey()])
+        ->callAction('archive')
+        ->assertNotified('Archived')
+        ->assertRedirect(ProjectResource::getUrl('index'));
+
+    expect($project->refresh()->isArchived())->toBeTrue();
+});
+
+it('archives the record from the view page', function () {
+    $project = Project::factory()->create();
+
+    Livewire::test(ViewProject::class, ['record' => $project->getRouteKey()])
+        ->callAction('archive')
+        ->assertNotified('Archived')
+        ->assertRedirect(ProjectResource::getUrl('index'));
+
+    expect($project->refresh()->isArchived())->toBeTrue();
+});
+
+it('deletes an unused record from the view page', function () {
+    $article = Article::factory()->create();
+
+    Livewire::test(ViewArticle::class, ['record' => $article->getRouteKey()])
+        ->assertActionHasLabel('archive', 'Delete')
+        ->callAction('archive')
+        ->assertNotified('Deleted')
+        ->assertRedirect(ArticleResource::getUrl('index'));
+
+    expect(Article::query()->whereKey($article->getKey())->exists())->toBeFalse();
+});
+
+it('is hidden when the record is already archived', function () {
+    $project = Project::factory()->create();
+    $project->archive();
+
+    Livewire::test(EditProject::class, ['record' => $project->getRouteKey()])
+        ->assertActionHidden('archive');
+});
+
+it('does not archive when the archiving event is cancelled', function () {
+    Project::archiving(fn (): bool => false);
+
+    $project = Project::factory()->create();
+
+    Livewire::test(EditProject::class, ['record' => $project->getRouteKey()])
+        ->callAction('archive')
+        ->assertNotNotified();
+
+    expect($project->refresh()->isArchived())->toBeFalse();
+});
+
+it('looks like an archive action when the record is used', function () {
+    $article = Article::factory()->create(['name' => 'Signals']);
+    Review::factory()->create(['article_id' => $article->id]);
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->assertActionHasLabel('archive', 'Archive')
+        ->assertActionHasColor('archive', 'warning')
+        ->assertActionExists('archive', fn (Action $action): bool => ((string) $action->getModalHeading()) === 'Archive Signals');
+});
+
+it('looks like a delete action when the record is unused', function () {
+    $article = Article::factory()->create(['name' => 'Signals']);
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->assertActionHasLabel('archive', 'Delete')
+        ->assertActionHasColor('archive', 'danger')
+        ->assertActionExists('archive', fn (Action $action): bool => ((string) $action->getModalHeading()) === 'Delete Signals')
+        ->assertActionExists('archive', fn (Action $action): bool => $action->getModalSubmitActionLabel() === 'Delete')
+        ->assertActionExists('archive', fn (Action $action): bool => $action->getModalIcon() === Heroicon::OutlinedTrash)
+        ->assertActionExists('archive', fn (Action $action): bool => $action->getGroupedIcon() === Heroicon::Trash);
+});
+
+it('archives a used record instead of deleting it', function () {
+    $article = Article::factory()->create();
+    Review::factory()->create(['article_id' => $article->id]);
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->callAction('archive')
+        ->assertNotified('Archived');
+
+    expect($article->refresh()->isArchived())->toBeTrue();
+});
+
+it('deletes an unused record and redirects to the index page', function () {
+    $article = Article::factory()->create();
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->callAction('archive')
+        ->assertNotified('Deleted')
+        ->assertRedirect(ArticleResource::getUrl('index'));
+
+    expect(Article::query()->whereKey($article->getKey())->exists())->toBeFalse();
+});
+
+it('remains visible as a delete action when an unused record is archived', function () {
+    $article = Article::factory()->create();
+    $article->archive();
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->assertActionVisible('archive')
+        ->assertActionHasLabel('archive', 'Delete');
+});
+
+it('is hidden when a used record is archived', function () {
+    $article = Article::factory()->create();
+    Review::factory()->create(['article_id' => $article->id]);
+    $article->archive();
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->assertActionHidden('archive');
+});
+
+it('is hidden when the user is not authorized to delete an unused record', function () {
+    ArticlePolicy::$abilities['delete'] = false;
+
+    $article = Article::factory()->create();
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->assertActionHidden('archive');
+});
+
+it('is hidden when the user is not authorized to archive a used record with the policy\'s `archive` method', function () {
+    ArticlePolicy::$abilities['archive'] = false;
+
+    $article = Article::factory()->create();
+    Review::factory()->create(['article_id' => $article->id]);
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->assertActionHidden('archive');
+});
+
+it('ignores the delete ability for a used record when the policy has an `archive` method', function () {
+    ArticlePolicy::$abilities['delete'] = false;
+
+    $article = Article::factory()->create();
+    Review::factory()->create(['article_id' => $article->id]);
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->assertActionVisible('archive')
+        ->callAction('archive')
+        ->assertNotified('Archived');
+
+    expect($article->refresh()->isArchived())->toBeTrue();
+});
+
+it('ignores the archive ability for an unused record', function () {
+    ArticlePolicy::$abilities['archive'] = false;
+
+    $article = Article::factory()->create();
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->assertActionVisible('archive')
+        ->callAction('archive')
+        ->assertNotified('Deleted');
+
+    expect(Article::query()->whereKey($article->getKey())->exists())->toBeFalse();
+});
+
+describe('backwards compatibility', function () {
+    it('is hidden when the user is not authorized to delete', function () {
+        ProjectPolicy::$abilities['delete'] = false;
+
+        $project = Project::factory()->create();
+
+        Livewire::test(EditProject::class, ['record' => $project->getRouteKey()])
+            ->assertActionHidden('archive');
+    });
+
+    it('falls back to the delete ability for a used record when the policy has no `archive` method', function () {
+        AttachmentPolicy::$abilities['delete'] = false;
+
+        $attachment = Attachment::factory()->used()->create();
+
+        Livewire::test(EditAttachment::class, ['record' => $attachment->getRouteKey()])
+            ->assertActionHidden('archive');
+    });
+
+    it('archives a used record using the delete ability when the policy has no `archive` method', function () {
+        $attachment = Attachment::factory()->used()->create();
+
+        Livewire::test(EditAttachment::class, ['record' => $attachment->getRouteKey()])
+            ->assertActionVisible('archive')
+            ->callAction('archive')
+            ->assertNotified('Archived');
+
+        expect($attachment->refresh()->isArchived())->toBeTrue();
+    });
+
+    it('authorizes archiving with the policy\'s `archive` method for a model without `isUsed()`', function () {
+        TagPolicy::$abilities['archive'] = false;
+
+        $tag = Tag::factory()->create();
+
+        Livewire::test(EditTag::class, ['record' => $tag->getRouteKey()])
+            ->assertActionHidden('archive');
+    });
+
+    it('ignores the delete ability for a model without `isUsed()` when the policy has an `archive` method', function () {
+        TagPolicy::$abilities['delete'] = false;
+
+        $tag = Tag::factory()->create();
+
+        Livewire::test(EditTag::class, ['record' => $tag->getRouteKey()])
+            ->assertActionVisible('archive')
+            ->callAction('archive')
+            ->assertNotified('Archived');
+
+        expect($tag->refresh()->isArchived())->toBeTrue();
+    });
+});
+
+it('does not delete when the deleting event is cancelled', function () {
+    Article::deleting(fn (): bool => false);
+
+    $article = Article::factory()->create();
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->callAction('archive')
+        ->assertNotNotified();
+
+    expect(Article::query()->whereKey($article->getKey())->exists())->toBeTrue();
+});
+
+it('throws when the model does not use the `CanBeArchived` trait', function () {
+    $task = Task::factory()->create();
+
+    Livewire::test(EditTask::class, ['record' => $task->getRouteKey()]);
+})->throws(Exception::class, 'The [ArchiveAction] requires the model to use the [CanBeArchived] trait.');
+
+it('deletes an archived record that is unused', function () {
+    $article = Article::factory()->create();
+    $article->archive();
+
+    Livewire::test(EditArticle::class, ['record' => $article->getRouteKey()])
+        ->callAction('archive')
+        ->assertNotified('Deleted');
+
+    expect(Article::query()->whereKey($article->getKey())->exists())->toBeFalse();
+});
+
+it('is hidden in delete mode when the record is soft-deleted', function () {
+    $attachment = Attachment::factory()->create();
+    $attachment->delete();
+
+    Livewire::test(EditAttachment::class, ['record' => $attachment->getRouteKey()])
+        ->assertActionHidden('archive');
+});
+
+it('remains visible in delete mode when a soft-deletable record is not trashed', function () {
+    $attachment = Attachment::factory()->create();
+
+    Livewire::test(EditAttachment::class, ['record' => $attachment->getRouteKey()])
+        ->assertActionVisible('archive')
+        ->assertActionHasLabel('archive', 'Delete');
+});
+
+it('soft-deletes an unused record when the model uses `SoftDeletes`', function () {
+    $attachment = Attachment::factory()->create();
+
+    Livewire::test(EditAttachment::class, ['record' => $attachment->getRouteKey()])
+        ->callAction('archive')
+        ->assertNotified('Deleted');
+
+    expect($attachment->refresh()->trashed())->toBeTrue();
+});
+
+it('is visible in archive mode even when the record is soft-deleted', function () {
+    $attachment = Attachment::factory()->used()->create();
+    $attachment->delete();
+
+    Livewire::test(EditAttachment::class, ['record' => $attachment->getRouteKey()])
+        ->assertActionVisible('archive')
+        ->assertActionHasLabel('archive', 'Archive');
+});

--- a/tests/Filament/Actions/ArchiveBulkActionTest.php
+++ b/tests/Filament/Actions/ArchiveBulkActionTest.php
@@ -1,0 +1,458 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Filament\Actions\BulkAction;
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use Workbench\App\Filament\Resources\Articles\ArticleResource;
+use Workbench\App\Filament\Resources\Articles\Pages\ListArticles;
+use Workbench\App\Filament\Resources\Images\ImageResource;
+use Workbench\App\Filament\Resources\Images\Pages\ListImages;
+use Workbench\App\Filament\Resources\Tasks\Pages\ListTasks;
+use Workbench\App\Models\Article;
+use Workbench\App\Models\Category;
+use Workbench\App\Models\Image;
+use Workbench\App\Models\Review;
+use Workbench\App\Models\Task;
+use Workbench\App\Models\User;
+use Workbench\App\Policies\ArticlePolicy;
+use Workbench\App\Policies\ImagePolicy;
+use Workbench\App\Policies\TaskPolicy;
+
+beforeEach(function () {
+    ArticlePolicy::reset();
+    ImagePolicy::reset();
+    TaskPolicy::reset();
+
+    ArticleResource::$authorizesIndividualRecords = false;
+    ArticleResource::$fetchesSelectedRecords = true;
+    ArticleResource::$selectedRecordsChunkSize = null;
+    ImageResource::$authorizesIndividualRecords = false;
+
+    Filament::setCurrentPanel('testing');
+
+    $this->actingAs(User::create(['name' => 'Ada', 'email' => 'ada@example.com']));
+});
+
+it('archives used records and deletes unused records', function () {
+    $usedArticles = Article::factory()->count(2)->create();
+    $usedArticles->each(fn (Article $article) => Review::factory()->create(['article_id' => $article->id]));
+
+    $unusedArticle = Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords(Article::query()->pluck('id')->all())
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('2 archived, 1 deleted');
+
+    $usedArticles->each(fn (Article $article) => expect($article->refresh()->isArchived())->toBeTrue());
+
+    expect(Article::query()->whereKey($unusedArticle->getKey())->exists())->toBeFalse();
+});
+
+it('archives every record when the model does not define `used()`', function () {
+    Image::factory()->count(3)->create();
+
+    Livewire::test(ListImages::class)
+        ->selectTableRecords(Image::query()->pluck('id')->all())
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('3 archived');
+
+    expect(Image::query()->onlyArchived()->count())->toBe(3);
+});
+
+it('only processes the selected records', function () {
+    $selectedArticle = Article::factory()->create();
+    $unselectedArticle = Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords([$selectedArticle->getKey()])
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('1 deleted');
+
+    expect(Article::query()->whereKey($selectedArticle->getKey())->exists())->toBeFalse();
+    expect($unselectedArticle->refresh()->isArchived())->toBeFalse();
+});
+
+it('fires model events and counts cancelled operations as failures', function () {
+    Article::deleting(fn (): bool => false);
+
+    $usedArticle = Article::factory()->create();
+    Review::factory()->create(['article_id' => $usedArticle->id]);
+
+    $unusedArticle = Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords([$usedArticle->getKey(), $unusedArticle->getKey()])
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified(
+            Notification::make()
+                ->warning()
+                ->title('1 archived')
+                ->body('<p>1 record failed to process.</p>')
+                ->persistent(),
+        );
+
+    expect($usedArticle->refresh()->isArchived())->toBeTrue();
+    expect(Article::query()->whereKey($unusedArticle->getKey())->exists())->toBeTrue();
+});
+
+it('counts cancelled archive operations as failures', function () {
+    Article::archiving(fn (): bool => false);
+
+    $usedArticle = Article::factory()->create();
+    Review::factory()->create(['article_id' => $usedArticle->id]);
+
+    $unusedArticle = Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords([$usedArticle->getKey(), $unusedArticle->getKey()])
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('1 deleted');
+
+    expect($usedArticle->refresh()->isArchived())->toBeFalse();
+    expect(Article::query()->whereKey($unusedArticle->getKey())->exists())->toBeFalse();
+});
+
+it('counts records that throw during processing as failures', function () {
+    Article::deleting(function (): void {
+        throw new RuntimeException('Delete failed.');
+    });
+
+    $usedArticle = Article::factory()->create();
+    Review::factory()->create(['article_id' => $usedArticle->id]);
+
+    $unusedArticle = Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords([$usedArticle->getKey(), $unusedArticle->getKey()])
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('1 archived');
+
+    expect($usedArticle->refresh()->isArchived())->toBeTrue();
+    expect(Article::query()->whereKey($unusedArticle->getKey())->exists())->toBeTrue();
+});
+
+it('processes records in bulk queries without model events when not fetching records', function () {
+    ArticleResource::$fetchesSelectedRecords = false;
+
+    $deletingEventFired = false;
+
+    Article::deleting(function () use (&$deletingEventFired): void {
+        $deletingEventFired = true;
+    });
+
+    $usedArticles = Article::factory()->count(2)->create();
+    $usedArticles->each(fn (Article $article) => Review::factory()->create(['article_id' => $article->id]));
+
+    $unusedArticle = Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords(Article::query()->pluck('id')->all())
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('2 archived, 1 deleted');
+
+    expect($deletingEventFired)->toBeFalse();
+
+    $usedArticles->each(fn (Article $article) => expect($article->refresh()->isArchived())->toBeTrue());
+
+    expect(Article::query()->whereKey($unusedArticle->getKey())->exists())->toBeFalse();
+});
+
+it('skips and reports records that fail individual `delete` authorization when it is enabled', function () {
+    ArticleResource::$authorizesIndividualRecords = true;
+
+    $usedArticle = Article::factory()->create();
+    Review::factory()->create(['article_id' => $usedArticle->id]);
+
+    $unusedArticle = Article::factory()->create();
+
+    $deniedArticle = Article::factory()->create();
+    ArticlePolicy::$deniedDeleteKeys = [$deniedArticle->getKey()];
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords(Article::query()->pluck('id')->all())
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('1 archived, 1 deleted');
+
+    expect($usedArticle->refresh()->isArchived())->toBeTrue();
+    expect(Article::query()->whereKey($unusedArticle->getKey())->exists())->toBeFalse();
+    expect($deniedArticle->refresh()->isArchived())->toBeFalse();
+});
+
+it('does not check the `delete` ability for each record by default', function () {
+    ArticlePolicy::$abilities['delete'] = false;
+
+    $article = Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords([$article->getKey()])
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('1 deleted');
+
+    expect(Article::query()->whereKey($article->getKey())->exists())->toBeFalse();
+});
+
+it('is hidden when the user is not authorized to delete any records', function () {
+    ArticlePolicy::$abilities['deleteAny'] = false;
+
+    Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->assertActionHidden(TestAction::make('archive')->table()->bulk());
+});
+
+it('throws when the model does not use the `CanBeArchived` trait', function () {
+    $task = Task::factory()->create();
+
+    Livewire::test(ListTasks::class)
+        ->selectTableRecords([$task->getKey()])
+        ->callAction(TestAction::make('archive')->table()->bulk());
+})->throws(Exception::class, 'The [ArchiveBulkAction] requires the model to use the [CanBeArchived] trait.');
+
+it('has archive styling and a delete warning in the modal when the model defines `used()`', function () {
+    Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->assertActionHasLabel(TestAction::make('archive')->table()->bulk(), 'Archive')
+        ->assertActionHasColor(TestAction::make('archive')->table()->bulk(), 'warning')
+        ->assertActionHasIcon(TestAction::make('archive')->table()->bulk(), Heroicon::ArchiveBox)
+        ->assertActionExists(TestAction::make('archive')->table()->bulk(), fn (BulkAction $action): bool => ((string) $action->getModalHeading()) === 'Archive Articles')
+        ->assertActionExists(TestAction::make('archive')->table()->bulk(), fn (BulkAction $action): bool => $action->getModalSubmitActionLabel() === 'Archive')
+        ->assertActionExists(TestAction::make('archive')->table()->bulk(), fn (BulkAction $action): bool => $action->getModalIcon() === Heroicon::OutlinedArchiveBox)
+        ->assertActionExists(TestAction::make('archive')->table()->bulk(), fn (BulkAction $action): bool => ((string) $action->getModalDescription()) === 'Records that are no longer in use will be permanently deleted instead of archived.');
+});
+
+it('has no delete warning in the modal when the model does not define `used()`', function () {
+    Image::factory()->create();
+
+    Livewire::test(ListImages::class)
+        ->assertActionExists(TestAction::make('archive')->table()->bulk(), fn (BulkAction $action): bool => ! str_contains((string) $action->getModalDescription(), 'permanently deleted'));
+});
+
+it('reports when no records could be processed because of authorization', function () {
+    ArticleResource::$authorizesIndividualRecords = true;
+    ArticlePolicy::$abilities['delete'] = false;
+
+    Article::factory()->count(2)->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords(Article::query()->pluck('id')->all())
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified(
+            Notification::make()
+                ->danger()
+                ->title('No records were archived or deleted')
+                ->body('<p>2 records could not be processed because you are not authorized to delete them.</p>')
+                ->persistent(),
+        );
+
+    expect(Article::query()->count())->toBe(2);
+    expect(Article::query()->onlyArchived()->count())->toBe(0);
+});
+
+it('reports skipped records alongside the successful counts when individual authorization fails', function () {
+    ArticleResource::$authorizesIndividualRecords = true;
+
+    $usedArticle = Article::factory()->create();
+    Review::factory()->create(['article_id' => $usedArticle->id]);
+
+    $unusedArticle = Article::factory()->create();
+
+    $deniedArticle = Article::factory()->create();
+    ArticlePolicy::$deniedDeleteKeys = [$deniedArticle->getKey()];
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords(Article::query()->pluck('id')->all())
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('1 archived, 1 deleted');
+
+    expect($deniedArticle->refresh()->isArchived())->toBeFalse();
+});
+
+it('does not authorize individual records when not fetching records', function () {
+    ArticleResource::$authorizesIndividualRecords = true;
+    ArticleResource::$fetchesSelectedRecords = false;
+    ArticlePolicy::$abilities['delete'] = false;
+
+    $article = Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords([$article->getKey()])
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('1 deleted');
+
+    expect(Article::query()->whereKey($article->getKey())->exists())->toBeFalse();
+});
+
+it('reports a complete failure when a bulk statement fails', function () {
+    ArticleResource::$fetchesSelectedRecords = false;
+
+    DB::statement(<<<'SQL'
+        CREATE TRIGGER fail_article_archives
+        BEFORE UPDATE ON articles
+        WHEN NEW.archived_at IS NOT NULL
+        BEGIN
+            SELECT RAISE(ABORT, 'Archiving is not allowed.');
+        END
+        SQL);
+
+    $usedArticle = Article::factory()->create();
+    Review::factory()->create(['article_id' => $usedArticle->id]);
+
+    $unusedArticle = Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords([$usedArticle->getKey(), $unusedArticle->getKey()])
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('No records were archived or deleted');
+
+    expect($usedArticle->refresh()->isArchived())->toBeFalse();
+    expect(Article::query()->whereKey($unusedArticle->getKey())->exists())->toBeTrue();
+});
+
+it('processes chunked selections', function () {
+    ArticleResource::$selectedRecordsChunkSize = 50;
+
+    $category = Category::factory()->create();
+
+    Article::factory()->count(120)->create(['category_id' => $category->id]);
+
+    $usedArticle = Article::factory()->create(['category_id' => $category->id]);
+    Review::factory()->create(['article_id' => $usedArticle->id]);
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords(Article::query()->pluck('id')->all())
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('1 archived, 120 deleted');
+
+    expect(Article::query()->count())->toBe(1);
+    expect($usedArticle->refresh()->isArchived())->toBeTrue();
+});
+
+it('does nothing when no records are selected', function () {
+    Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('No records were archived or deleted');
+
+    expect(Article::query()->count())->toBe(1);
+    expect(Article::query()->onlyArchived()->count())->toBe(0);
+});
+
+it('authorizes records that will be archived with the `archive` ability when the policy has an `archive` method', function () {
+    ArticleResource::$authorizesIndividualRecords = true;
+    ArticlePolicy::$abilities['archive'] = false;
+
+    $usedArticle = Article::factory()->create();
+    Review::factory()->create(['article_id' => $usedArticle->id]);
+
+    $unusedArticle = Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords([$usedArticle->getKey(), $unusedArticle->getKey()])
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('1 deleted');
+
+    expect($usedArticle->refresh()->isArchived())->toBeFalse();
+    expect(Article::query()->whereKey($unusedArticle->getKey())->exists())->toBeFalse();
+});
+
+it('ignores the delete ability for records that will be archived when the policy has an `archive` method', function () {
+    ArticleResource::$authorizesIndividualRecords = true;
+    ArticlePolicy::$abilities['delete'] = false;
+
+    $usedArticle = Article::factory()->create();
+    Review::factory()->create(['article_id' => $usedArticle->id]);
+
+    $unusedArticle = Article::factory()->create();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords([$usedArticle->getKey(), $unusedArticle->getKey()])
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('1 archived');
+
+    expect($usedArticle->refresh()->isArchived())->toBeTrue();
+    expect(Article::query()->whereKey($unusedArticle->getKey())->exists())->toBeTrue();
+});
+
+describe('backwards compatibility', function () {
+    it('falls back to the delete ability for records that will be archived when the policy has no `archive` method', function () {
+        ImageResource::$authorizesIndividualRecords = true;
+        ImagePolicy::$abilities['delete'] = false;
+
+        Image::factory()->count(2)->create();
+
+        Livewire::test(ListImages::class)
+            ->selectTableRecords(Image::query()->pluck('id')->all())
+            ->callAction(TestAction::make('archive')->table()->bulk())
+            ->assertNotified('No records were archived or deleted');
+
+        expect(Image::query()->onlyArchived()->count())->toBe(0);
+    });
+
+    it('archives records using the delete ability when the policy has no `archive` method', function () {
+        ImageResource::$authorizesIndividualRecords = true;
+
+        Image::factory()->count(2)->create();
+
+        Livewire::test(ListImages::class)
+            ->selectTableRecords(Image::query()->pluck('id')->all())
+            ->callAction(TestAction::make('archive')->table()->bulk())
+            ->assertNotified('2 archived');
+
+        expect(Image::query()->onlyArchived()->count())->toBe(2);
+    });
+});
+
+it('includes already-archived used records in the archived count', function () {
+    $usedArticles = Article::factory()->count(2)->create();
+    $usedArticles->each(fn (Article $article) => Review::factory()->create(['article_id' => $article->id]));
+
+    $usedArticles->first()->archive();
+
+    Livewire::test(ListArticles::class)
+        ->selectTableRecords($usedArticles->pluck('id')->all())
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified('2 archived');
+
+    expect(Article::query()->onlyArchived()->count())->toBe(2);
+});

--- a/tests/Filament/Actions/ArchiveBulkActionTest.php
+++ b/tests/Filament/Actions/ArchiveBulkActionTest.php
@@ -251,7 +251,7 @@ it('has archive styling and a delete warning in the modal when the model defines
     Article::factory()->create();
 
     Livewire::test(ListArticles::class)
-        ->assertActionHasLabel(TestAction::make('archive')->table()->bulk(), 'Archive')
+        ->assertActionHasLabel(TestAction::make('archive')->table()->bulk(), 'Archive / Delete')
         ->assertActionHasColor(TestAction::make('archive')->table()->bulk(), 'warning')
         ->assertActionHasIcon(TestAction::make('archive')->table()->bulk(), Heroicon::ArchiveBox)
         ->assertActionExists(TestAction::make('archive')->table()->bulk(), fn (BulkAction $action): bool => ((string) $action->getModalHeading()) === 'Archive Articles')
@@ -264,6 +264,7 @@ it('has no delete warning in the modal when the model does not define `used()`',
     Image::factory()->create();
 
     Livewire::test(ListImages::class)
+        ->assertActionHasLabel(TestAction::make('archive')->table()->bulk(), 'Archive')
         ->assertActionExists(TestAction::make('archive')->table()->bulk(), fn (BulkAction $action): bool => ! str_contains((string) $action->getModalDescription(), 'permanently deleted'));
 });
 

--- a/tests/Models/Concerns/CanBeArchivedTest.php
+++ b/tests/Models/Concerns/CanBeArchivedTest.php
@@ -35,7 +35,9 @@
 */
 
 use Illuminate\Support\Carbon;
+use Workbench\App\Models\Article;
 use Workbench\App\Models\Project;
+use Workbench\App\Models\Review;
 use Workbench\App\Models\Task;
 
 it('can archive a model', function () {
@@ -255,3 +257,25 @@ it('excludes archived and unused models with `withoutArchivedAndUnused` scope', 
 it('throws `BadMethodCallException` when using `withoutArchivedAndUnused` without a `used` method', function () {
     Task::query()->withoutArchivedAndUnused();
 })->throws(BadMethodCallException::class);
+
+it('reads an eager-loaded relation existence attribute in `isUsed()` instead of querying', function () {
+    $article = Article::factory()->create();
+    Review::factory()->create(['article_id' => $article->id]);
+
+    $article = Article::query()->withExists('reviews')->find($article->getKey());
+
+    Review::query()->delete();
+
+    expect($article->isUsed())->toBeTrue();
+});
+
+it('memoizes the relation existence in `isUsed()` after the first check', function () {
+    $article = Article::factory()->create();
+
+    expect($article->isUsed())->toBeFalse();
+
+    Review::factory()->create(['article_id' => $article->id]);
+
+    expect($article->isUsed())->toBeFalse();
+    expect($article->fresh()->isUsed())->toBeTrue();
+});

--- a/workbench/app/Filament/Resources/Articles/ArticleResource.php
+++ b/workbench/app/Filament/Resources/Articles/ArticleResource.php
@@ -34,47 +34,52 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Articles;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use CanyonGBS\Common\Filament\Actions\ArchiveBulkAction;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Workbench\App\Filament\Resources\Articles\Pages\EditArticle;
+use Workbench\App\Filament\Resources\Articles\Pages\ListArticles;
+use Workbench\App\Filament\Resources\Articles\Pages\ViewArticle;
+use Workbench\App\Models\Article;
 
-abstract class TestCase extends Orchestra
+/**
+ * @extends Resource<Article>
+ */
+class ArticleResource extends Resource
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static ?string $model = Article::class;
 
-    protected function resolveApplication()
+    protected static ?string $recordTitleAttribute = 'name';
+
+    public static bool $authorizesIndividualRecords = false;
+
+    public static bool $fetchesSelectedRecords = true;
+
+    public static ?int $selectedRecordsChunkSize = null;
+
+    public static function table(Table $table): Table
     {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
+        return $table
+            ->columns([
+                TextColumn::make('name'),
+            ])
+            ->toolbarActions([
+                ArchiveBulkAction::make()
+                    ->authorizeIndividualRecords(static::$authorizesIndividualRecords ? 'delete' : null)
+                    ->fetchSelectedRecords(static::$fetchesSelectedRecords)
+                    ->chunkSelectedRecords(static::$selectedRecordsChunkSize),
+            ]);
     }
 
-    protected function getPackageProviders($app): array
+    public static function getPages(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            'index' => ListArticles::route('/'),
+            'view' => ViewArticle::route('/{record}'),
+            'edit' => EditArticle::route('/{record}/edit'),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Articles/Pages/EditArticle.php
+++ b/workbench/app/Filament/Resources/Articles/Pages/EditArticle.php
@@ -34,47 +34,20 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Articles\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use CanyonGBS\Common\Filament\Actions\ArchiveAction;
+use Filament\Resources\Pages\EditRecord;
+use Workbench\App\Filament\Resources\Articles\ArticleResource;
 
-abstract class TestCase extends Orchestra
+class EditArticle extends EditRecord
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static string $resource = ArticleResource::class;
 
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
+    protected function getHeaderActions(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            ArchiveAction::make(),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Articles/Pages/ListArticles.php
+++ b/workbench/app/Filament/Resources/Articles/Pages/ListArticles.php
@@ -34,47 +34,12 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Articles\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use Filament\Resources\Pages\ListRecords;
+use Workbench\App\Filament\Resources\Articles\ArticleResource;
 
-abstract class TestCase extends Orchestra
+class ListArticles extends ListRecords
 {
-    protected $enablesPackageDiscoveries = true;
-
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
-    {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
-    }
+    protected static string $resource = ArticleResource::class;
 }

--- a/workbench/app/Filament/Resources/Articles/Pages/ViewArticle.php
+++ b/workbench/app/Filament/Resources/Articles/Pages/ViewArticle.php
@@ -34,47 +34,20 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Articles\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use CanyonGBS\Common\Filament\Actions\ArchiveAction;
+use Filament\Resources\Pages\ViewRecord;
+use Workbench\App\Filament\Resources\Articles\ArticleResource;
 
-abstract class TestCase extends Orchestra
+class ViewArticle extends ViewRecord
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static string $resource = ArticleResource::class;
 
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
+    protected function getHeaderActions(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            ArchiveAction::make(),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Attachments/AttachmentResource.php
+++ b/workbench/app/Filament/Resources/Attachments/AttachmentResource.php
@@ -34,47 +34,33 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Attachments;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use Filament\Resources\Resource;
+use Illuminate\Database\Eloquent\Builder;
+use Workbench\App\Filament\Resources\Attachments\Pages\EditAttachment;
+use Workbench\App\Filament\Resources\Attachments\Pages\ListAttachments;
+use Workbench\App\Models\Attachment;
 
-abstract class TestCase extends Orchestra
+/**
+ * @extends Resource<Attachment>
+ */
+class AttachmentResource extends Resource
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static ?string $model = Attachment::class;
 
-    protected function resolveApplication()
+    protected static ?string $recordTitleAttribute = 'name';
+
+    public static function getRecordRouteBindingEloquentQuery(): Builder
     {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
+        return parent::getRecordRouteBindingEloquentQuery()->withTrashed(); /** @phpstan-ignore method.notFound */
     }
 
-    protected function getPackageProviders($app): array
+    public static function getPages(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            'index' => ListAttachments::route('/'),
+            'edit' => EditAttachment::route('/{record}/edit'),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Attachments/Pages/EditAttachment.php
+++ b/workbench/app/Filament/Resources/Attachments/Pages/EditAttachment.php
@@ -34,47 +34,20 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Attachments\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use CanyonGBS\Common\Filament\Actions\ArchiveAction;
+use Filament\Resources\Pages\EditRecord;
+use Workbench\App\Filament\Resources\Attachments\AttachmentResource;
 
-abstract class TestCase extends Orchestra
+class EditAttachment extends EditRecord
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static string $resource = AttachmentResource::class;
 
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
+    protected function getHeaderActions(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            ArchiveAction::make(),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Attachments/Pages/ListAttachments.php
+++ b/workbench/app/Filament/Resources/Attachments/Pages/ListAttachments.php
@@ -34,47 +34,12 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Attachments\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use Filament\Resources\Pages\ListRecords;
+use Workbench\App\Filament\Resources\Attachments\AttachmentResource;
 
-abstract class TestCase extends Orchestra
+class ListAttachments extends ListRecords
 {
-    protected $enablesPackageDiscoveries = true;
-
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
-    {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
-    }
+    protected static string $resource = AttachmentResource::class;
 }

--- a/workbench/app/Filament/Resources/Images/ImageResource.php
+++ b/workbench/app/Filament/Resources/Images/ImageResource.php
@@ -34,47 +34,40 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Images;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use CanyonGBS\Common\Filament\Actions\ArchiveBulkAction;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Workbench\App\Filament\Resources\Images\Pages\ListImages;
+use Workbench\App\Models\Image;
 
-abstract class TestCase extends Orchestra
+/**
+ * @extends Resource<Image>
+ */
+class ImageResource extends Resource
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static ?string $model = Image::class;
 
-    protected function resolveApplication()
+    public static bool $authorizesIndividualRecords = false;
+
+    public static function table(Table $table): Table
     {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
+        return $table
+            ->columns([
+                TextColumn::make('url'),
+            ])
+            ->toolbarActions([
+                ArchiveBulkAction::make()
+                    ->authorizeIndividualRecords(static::$authorizesIndividualRecords ? 'delete' : null),
+            ]);
     }
 
-    protected function getPackageProviders($app): array
+    public static function getPages(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            'index' => ListImages::route('/'),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Images/Pages/ListImages.php
+++ b/workbench/app/Filament/Resources/Images/Pages/ListImages.php
@@ -34,47 +34,12 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Images\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use Filament\Resources\Pages\ListRecords;
+use Workbench\App\Filament\Resources\Images\ImageResource;
 
-abstract class TestCase extends Orchestra
+class ListImages extends ListRecords
 {
-    protected $enablesPackageDiscoveries = true;
-
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
-    {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
-    }
+    protected static string $resource = ImageResource::class;
 }

--- a/workbench/app/Filament/Resources/Projects/Pages/EditProject.php
+++ b/workbench/app/Filament/Resources/Projects/Pages/EditProject.php
@@ -34,47 +34,20 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Projects\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use CanyonGBS\Common\Filament\Actions\ArchiveAction;
+use Filament\Resources\Pages\EditRecord;
+use Workbench\App\Filament\Resources\Projects\ProjectResource;
 
-abstract class TestCase extends Orchestra
+class EditProject extends EditRecord
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static string $resource = ProjectResource::class;
 
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
+    protected function getHeaderActions(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            ArchiveAction::make(),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Projects/Pages/ListProjects.php
+++ b/workbench/app/Filament/Resources/Projects/Pages/ListProjects.php
@@ -34,47 +34,12 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Projects\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use Filament\Resources\Pages\ListRecords;
+use Workbench\App\Filament\Resources\Projects\ProjectResource;
 
-abstract class TestCase extends Orchestra
+class ListProjects extends ListRecords
 {
-    protected $enablesPackageDiscoveries = true;
-
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
-    {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
-    }
+    protected static string $resource = ProjectResource::class;
 }

--- a/workbench/app/Filament/Resources/Projects/Pages/ViewProject.php
+++ b/workbench/app/Filament/Resources/Projects/Pages/ViewProject.php
@@ -34,47 +34,20 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Projects\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use CanyonGBS\Common\Filament\Actions\ArchiveAction;
+use Filament\Resources\Pages\ViewRecord;
+use Workbench\App\Filament\Resources\Projects\ProjectResource;
 
-abstract class TestCase extends Orchestra
+class ViewProject extends ViewRecord
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static string $resource = ProjectResource::class;
 
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
+    protected function getHeaderActions(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            ArchiveAction::make(),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Projects/ProjectResource.php
+++ b/workbench/app/Filament/Resources/Projects/ProjectResource.php
@@ -34,47 +34,29 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Projects;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use Filament\Resources\Resource;
+use Workbench\App\Filament\Resources\Projects\Pages\EditProject;
+use Workbench\App\Filament\Resources\Projects\Pages\ListProjects;
+use Workbench\App\Filament\Resources\Projects\Pages\ViewProject;
+use Workbench\App\Models\Project;
 
-abstract class TestCase extends Orchestra
+/**
+ * @extends Resource<Project>
+ */
+class ProjectResource extends Resource
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static ?string $model = Project::class;
 
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
+    protected static ?string $recordTitleAttribute = 'name';
 
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
+    public static function getPages(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            'index' => ListProjects::route('/'),
+            'view' => ViewProject::route('/{record}'),
+            'edit' => EditProject::route('/{record}/edit'),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Tags/Pages/EditTag.php
+++ b/workbench/app/Filament/Resources/Tags/Pages/EditTag.php
@@ -34,47 +34,20 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Tags\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use CanyonGBS\Common\Filament\Actions\ArchiveAction;
+use Filament\Resources\Pages\EditRecord;
+use Workbench\App\Filament\Resources\Tags\TagResource;
 
-abstract class TestCase extends Orchestra
+class EditTag extends EditRecord
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static string $resource = TagResource::class;
 
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
+    protected function getHeaderActions(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            ArchiveAction::make(),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Tags/Pages/ListTags.php
+++ b/workbench/app/Filament/Resources/Tags/Pages/ListTags.php
@@ -34,47 +34,12 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Tags\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use Filament\Resources\Pages\ListRecords;
+use Workbench\App\Filament\Resources\Tags\TagResource;
 
-abstract class TestCase extends Orchestra
+class ListTags extends ListRecords
 {
-    protected $enablesPackageDiscoveries = true;
-
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
-    {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
-    }
+    protected static string $resource = TagResource::class;
 }

--- a/workbench/app/Filament/Resources/Tags/TagResource.php
+++ b/workbench/app/Filament/Resources/Tags/TagResource.php
@@ -34,47 +34,27 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Tags;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use Filament\Resources\Resource;
+use Workbench\App\Filament\Resources\Tags\Pages\EditTag;
+use Workbench\App\Filament\Resources\Tags\Pages\ListTags;
+use Workbench\App\Models\Tag;
 
-abstract class TestCase extends Orchestra
+/**
+ * @extends Resource<Tag>
+ */
+class TagResource extends Resource
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static ?string $model = Tag::class;
 
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
+    protected static ?string $recordTitleAttribute = 'name';
 
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
+    public static function getPages(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            'index' => ListTags::route('/'),
+            'edit' => EditTag::route('/{record}/edit'),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Tasks/Pages/EditTask.php
+++ b/workbench/app/Filament/Resources/Tasks/Pages/EditTask.php
@@ -34,47 +34,20 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Tasks\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use CanyonGBS\Common\Filament\Actions\ArchiveAction;
+use Filament\Resources\Pages\EditRecord;
+use Workbench\App\Filament\Resources\Tasks\TaskResource;
 
-abstract class TestCase extends Orchestra
+class EditTask extends EditRecord
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static string $resource = TaskResource::class;
 
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
+    protected function getHeaderActions(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            ArchiveAction::make(),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Filament/Resources/Tasks/Pages/ListTasks.php
+++ b/workbench/app/Filament/Resources/Tasks/Pages/ListTasks.php
@@ -34,47 +34,12 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Tasks\Pages;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use Filament\Resources\Pages\ListRecords;
+use Workbench\App\Filament\Resources\Tasks\TaskResource;
 
-abstract class TestCase extends Orchestra
+class ListTasks extends ListRecords
 {
-    protected $enablesPackageDiscoveries = true;
-
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
-    {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
-    }
+    protected static string $resource = TaskResource::class;
 }

--- a/workbench/app/Filament/Resources/Tasks/TaskResource.php
+++ b/workbench/app/Filament/Resources/Tasks/TaskResource.php
@@ -34,47 +34,41 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Filament\Resources\Tasks;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use CanyonGBS\Common\Filament\Actions\ArchiveBulkAction;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Workbench\App\Filament\Resources\Tasks\Pages\EditTask;
+use Workbench\App\Filament\Resources\Tasks\Pages\ListTasks;
+use Workbench\App\Models\Task;
 
-abstract class TestCase extends Orchestra
+/**
+ * @extends Resource<Task>
+ */
+class TaskResource extends Resource
 {
-    protected $enablesPackageDiscoveries = true;
+    protected static ?string $model = Task::class;
 
-    protected function resolveApplication()
+    protected static ?string $recordTitleAttribute = 'name';
+
+    public static function table(Table $table): Table
     {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
+        return $table
+            ->columns([
+                TextColumn::make('name'),
+            ])
+            ->toolbarActions([
+                ArchiveBulkAction::make(),
+            ]);
     }
 
-    protected function getPackageProviders($app): array
+    public static function getPages(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            'index' => ListTasks::route('/'),
+            'edit' => EditTask::route('/{record}/edit'),
         ];
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
     }
 }

--- a/workbench/app/Models/Article.php
+++ b/workbench/app/Models/Article.php
@@ -72,6 +72,11 @@ class Article extends Model
         $query->whereHas('reviews');
     }
 
+    public function isUsed(): bool
+    {
+        return (bool) ($this->reviews_exists ??= $this->reviews()->exists());
+    }
+
     protected static function newFactory(): ArticleFactory
     {
         return ArticleFactory::new();

--- a/workbench/app/Models/Attachment.php
+++ b/workbench/app/Models/Attachment.php
@@ -34,47 +34,35 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Models;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use CanyonGBS\Common\Models\Concerns\CanBeArchived;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Workbench\Database\Factories\AttachmentFactory;
 
-abstract class TestCase extends Orchestra
+class Attachment extends Model
 {
-    protected $enablesPackageDiscoveries = true;
+    use CanBeArchived;
+    use HasFactory;
+    use SoftDeletes;
 
-    protected function resolveApplication()
+    protected $guarded = [];
+
+    public function used(Builder $query): void
     {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
+        $query->where('is_used', true);
     }
 
-    protected function getPackageProviders($app): array
+    public function isUsed(): bool
     {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
+        return (bool) $this->is_used;
     }
 
-    protected function defineEnvironment($app): void
+    protected static function newFactory(): AttachmentFactory
     {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
+        return AttachmentFactory::new();
     }
 }

--- a/workbench/app/Policies/ArticlePolicy.php
+++ b/workbench/app/Policies/ArticlePolicy.php
@@ -34,47 +34,60 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Policies;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
+use Workbench\App\Models\Article;
 use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
 
-abstract class TestCase extends Orchestra
+class ArticlePolicy
 {
-    protected $enablesPackageDiscoveries = true;
+    /**
+     * @var array<string, bool>
+     */
+    public static array $abilities = [];
 
-    protected function resolveApplication()
+    /**
+     * @var array<int, mixed>
+     */
+    public static array $deniedDeleteKeys = [];
+
+    public static function reset(): void
     {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
+        static::$abilities = [];
+        static::$deniedDeleteKeys = [];
     }
 
-    protected function getPackageProviders($app): array
+    public function viewAny(User $user): bool
     {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
+        return static::$abilities['viewAny'] ?? true;
     }
 
-    protected function defineEnvironment($app): void
+    public function view(User $user, Article $article): bool
     {
-        $app['config']->set('auth.providers.users.model', User::class);
+        return static::$abilities['view'] ?? true;
     }
 
-    protected function defineDatabaseMigrations(): void
+    public function update(User $user, Article $article): bool
     {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
+        return static::$abilities['update'] ?? true;
+    }
+
+    public function delete(User $user, Article $article): bool
+    {
+        if (in_array($article->getKey(), static::$deniedDeleteKeys)) {
+            return false;
+        }
+
+        return static::$abilities['delete'] ?? true;
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return static::$abilities['deleteAny'] ?? true;
+    }
+
+    public function archive(User $user, Article $article): bool
+    {
+        return static::$abilities['archive'] ?? true;
     }
 }

--- a/workbench/app/Policies/AttachmentPolicy.php
+++ b/workbench/app/Policies/AttachmentPolicy.php
@@ -34,47 +34,45 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Policies;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
+use Workbench\App\Models\Attachment;
 use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
 
-abstract class TestCase extends Orchestra
+class AttachmentPolicy
 {
-    protected $enablesPackageDiscoveries = true;
+    /**
+     * @var array<string, bool>
+     */
+    public static array $abilities = [];
 
-    protected function resolveApplication()
+    public static function reset(): void
     {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
+        static::$abilities = [];
     }
 
-    protected function getPackageProviders($app): array
+    public function viewAny(User $user): bool
     {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
+        return static::$abilities['viewAny'] ?? true;
     }
 
-    protected function defineEnvironment($app): void
+    public function view(User $user, Attachment $attachment): bool
     {
-        $app['config']->set('auth.providers.users.model', User::class);
+        return static::$abilities['view'] ?? true;
     }
 
-    protected function defineDatabaseMigrations(): void
+    public function update(User $user, Attachment $attachment): bool
     {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
+        return static::$abilities['update'] ?? true;
+    }
+
+    public function delete(User $user, Attachment $attachment): bool
+    {
+        return static::$abilities['delete'] ?? true;
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return static::$abilities['deleteAny'] ?? true;
     }
 }

--- a/workbench/app/Policies/ImagePolicy.php
+++ b/workbench/app/Policies/ImagePolicy.php
@@ -34,47 +34,40 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Policies;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
+use Workbench\App\Models\Image;
 use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
 
-abstract class TestCase extends Orchestra
+class ImagePolicy
 {
-    protected $enablesPackageDiscoveries = true;
+    /**
+     * @var array<string, bool>
+     */
+    public static array $abilities = [];
 
-    protected function resolveApplication()
+    public static function reset(): void
     {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
+        static::$abilities = [];
     }
 
-    protected function getPackageProviders($app): array
+    public function viewAny(User $user): bool
     {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
+        return static::$abilities['viewAny'] ?? true;
     }
 
-    protected function defineEnvironment($app): void
+    public function view(User $user, Image $image): bool
     {
-        $app['config']->set('auth.providers.users.model', User::class);
+        return static::$abilities['view'] ?? true;
     }
 
-    protected function defineDatabaseMigrations(): void
+    public function delete(User $user, Image $image): bool
     {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
+        return static::$abilities['delete'] ?? true;
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return static::$abilities['deleteAny'] ?? true;
     }
 }

--- a/workbench/app/Policies/ProjectPolicy.php
+++ b/workbench/app/Policies/ProjectPolicy.php
@@ -34,47 +34,40 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Policies;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
+use Workbench\App\Models\Project;
 use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
 
-abstract class TestCase extends Orchestra
+class ProjectPolicy
 {
-    protected $enablesPackageDiscoveries = true;
+    /**
+     * @var array<string, bool>
+     */
+    public static array $abilities = [];
 
-    protected function resolveApplication()
+    public static function reset(): void
     {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
+        static::$abilities = [];
     }
 
-    protected function getPackageProviders($app): array
+    public function viewAny(User $user): bool
     {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
+        return static::$abilities['viewAny'] ?? true;
     }
 
-    protected function defineEnvironment($app): void
+    public function view(User $user, Project $project): bool
     {
-        $app['config']->set('auth.providers.users.model', User::class);
+        return static::$abilities['view'] ?? true;
     }
 
-    protected function defineDatabaseMigrations(): void
+    public function update(User $user, Project $project): bool
     {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
+        return static::$abilities['update'] ?? true;
+    }
+
+    public function delete(User $user, Project $project): bool
+    {
+        return static::$abilities['delete'] ?? true;
     }
 }

--- a/workbench/app/Policies/TagPolicy.php
+++ b/workbench/app/Policies/TagPolicy.php
@@ -34,47 +34,45 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Policies;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
+use Workbench\App\Models\Tag;
 use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
 
-abstract class TestCase extends Orchestra
+class TagPolicy
 {
-    protected $enablesPackageDiscoveries = true;
+    /**
+     * @var array<string, bool>
+     */
+    public static array $abilities = [];
 
-    protected function resolveApplication()
+    public static function reset(): void
     {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
+        static::$abilities = [];
     }
 
-    protected function getPackageProviders($app): array
+    public function viewAny(User $user): bool
     {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
+        return static::$abilities['viewAny'] ?? true;
     }
 
-    protected function defineEnvironment($app): void
+    public function view(User $user, Tag $tag): bool
     {
-        $app['config']->set('auth.providers.users.model', User::class);
+        return static::$abilities['view'] ?? true;
     }
 
-    protected function defineDatabaseMigrations(): void
+    public function update(User $user, Tag $tag): bool
     {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
+        return static::$abilities['update'] ?? true;
+    }
+
+    public function delete(User $user, Tag $tag): bool
+    {
+        return static::$abilities['delete'] ?? true;
+    }
+
+    public function archive(User $user, Tag $tag): bool
+    {
+        return static::$abilities['archive'] ?? true;
     }
 }

--- a/workbench/app/Policies/TaskPolicy.php
+++ b/workbench/app/Policies/TaskPolicy.php
@@ -34,47 +34,45 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\App\Policies;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
+use Workbench\App\Models\Task;
 use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
 
-abstract class TestCase extends Orchestra
+class TaskPolicy
 {
-    protected $enablesPackageDiscoveries = true;
+    /**
+     * @var array<string, bool>
+     */
+    public static array $abilities = [];
 
-    protected function resolveApplication()
+    public static function reset(): void
     {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
+        static::$abilities = [];
     }
 
-    protected function getPackageProviders($app): array
+    public function viewAny(User $user): bool
     {
-        return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
-        ];
+        return static::$abilities['viewAny'] ?? true;
     }
 
-    protected function defineEnvironment($app): void
+    public function view(User $user, Task $task): bool
     {
-        $app['config']->set('auth.providers.users.model', User::class);
+        return static::$abilities['view'] ?? true;
     }
 
-    protected function defineDatabaseMigrations(): void
+    public function update(User $user, Task $task): bool
     {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
+        return static::$abilities['update'] ?? true;
+    }
+
+    public function delete(User $user, Task $task): bool
+    {
+        return static::$abilities['delete'] ?? true;
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return static::$abilities['deleteAny'] ?? true;
     }
 }

--- a/workbench/app/Providers/TestingPanelProvider.php
+++ b/workbench/app/Providers/TestingPanelProvider.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace Workbench\App\Providers;
+
+use Filament\Panel;
+use Filament\PanelProvider;
+use Illuminate\Support\Facades\Gate;
+use Workbench\App\Filament\Resources\Articles\ArticleResource;
+use Workbench\App\Filament\Resources\Attachments\AttachmentResource;
+use Workbench\App\Filament\Resources\Images\ImageResource;
+use Workbench\App\Filament\Resources\Projects\ProjectResource;
+use Workbench\App\Filament\Resources\Tags\TagResource;
+use Workbench\App\Filament\Resources\Tasks\TaskResource;
+use Workbench\App\Models\Article;
+use Workbench\App\Models\Attachment;
+use Workbench\App\Models\Image;
+use Workbench\App\Models\Project;
+use Workbench\App\Models\Tag;
+use Workbench\App\Models\Task;
+use Workbench\App\Policies\ArticlePolicy;
+use Workbench\App\Policies\AttachmentPolicy;
+use Workbench\App\Policies\ImagePolicy;
+use Workbench\App\Policies\ProjectPolicy;
+use Workbench\App\Policies\TagPolicy;
+use Workbench\App\Policies\TaskPolicy;
+
+class TestingPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('testing')
+            ->path('testing')
+            ->default()
+            ->resources([
+                ArticleResource::class,
+                AttachmentResource::class,
+                ImageResource::class,
+                ProjectResource::class,
+                TagResource::class,
+                TaskResource::class,
+            ]);
+    }
+
+    public function boot(): void
+    {
+        Gate::policy(Article::class, ArticlePolicy::class);
+        Gate::policy(Attachment::class, AttachmentPolicy::class);
+        Gate::policy(Image::class, ImagePolicy::class);
+        Gate::policy(Project::class, ProjectPolicy::class);
+        Gate::policy(Tag::class, TagPolicy::class);
+        Gate::policy(Task::class, TaskPolicy::class);
+    }
+}

--- a/workbench/database/factories/AttachmentFactory.php
+++ b/workbench/database/factories/AttachmentFactory.php
@@ -34,47 +34,27 @@
 </COPYRIGHT>
 */
 
-namespace CanyonGBS\Common\Tests;
+namespace Workbench\Database\Factories;
 
-use CanyonGBS\Common\CommonServiceProvider;
-use Orchestra\Testbench\Foundation\Actions\CreateVendorSymlink;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Workbench\App\Models\User;
-use Workbench\App\Providers\TestingPanelProvider;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Attachment;
 
-abstract class TestCase extends Orchestra
+/** @extends Factory<Attachment> */
+class AttachmentFactory extends Factory
 {
-    protected $enablesPackageDiscoveries = true;
+    protected $model = Attachment::class;
 
-    protected function resolveApplication()
-    {
-        $app = parent::resolveApplication();
-
-        // Package discovery reads the skeleton's `vendor` directory, which
-        // must be symlinked to this package's `vendor` directory. The path is
-        // resolved explicitly instead of with `package_path()`, which reports
-        // Rector's bundled `vendor` directory once a Rector test class has
-        // been autoloaded.
-        (new CreateVendorSymlink(dirname(__DIR__) . '/vendor'))->handle(clone $app);
-
-        return $app;
-    }
-
-    protected function getPackageProviders($app): array
+    /** @return array<string, mixed> */
+    public function definition(): array
     {
         return [
-            CommonServiceProvider::class,
-            TestingPanelProvider::class,
+            'name' => $this->faker->sentence(),
+            'is_used' => false,
         ];
     }
 
-    protected function defineEnvironment($app): void
+    public function used(): static
     {
-        $app['config']->set('auth.providers.users.model', User::class);
-    }
-
-    protected function defineDatabaseMigrations(): void
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/../workbench/database/migrations');
+        return $this->state(['is_used' => true]);
     }
 }

--- a/workbench/database/migrations/0001_01_01_000001_create_test_tables.php
+++ b/workbench/database/migrations/0001_01_01_000001_create_test_tables.php
@@ -116,10 +116,20 @@ return new class () extends Migration {
             $table->text('body');
             $table->timestamps();
         });
+
+        Schema::create('attachments', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->boolean('is_used')->default(false);
+            $table->timestamp('archived_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
     }
 
     public function down(): void
     {
+        Schema::dropIfExists('attachments');
         Schema::dropIfExists('reviews');
         Schema::dropIfExists('articles');
         Schema::dropIfExists('categories');


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2813

### Technical Description

Introduces the ability for the `ArchiveAction` to act as a delete if the model has an `isUsed()` method and returns `false`. Introduces `ArchiveBulkDeletion` that does the same over multiple records and reports its progress. Adds test suite for both actions and more thorough docs for archiving.

Preserves BC for the old `archive()` policy method but it is redundant in new implementations as `delete()` is read instead.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/common/blob/main/README.md#contributing).
