### PR TITLE
[Chore]: Switch to CGBS Automation App instead of PAT

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -22,13 +22,21 @@ jobs:
         timeout-minutes: 10
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  permission-contents: write
+
             - name: Checkout code | Internal
               if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }} # zizmor: ignore[secrets-outside-env]
-                  persist-credentials: true # zizmor: ignore[artipacked] -- credentials needed for git push
+                  persist-credentials: false
 
             - name: Checkout code | External
               if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' }}
@@ -43,19 +51,39 @@ jobs:
             - name: Run Ruby Script
               run: ruby ./copyright.rb
 
+            - name: Get GitHub App User ID
+              id: get-user-id
+              if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
+              env:
+                  APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
             - name: Commit changes
               if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
+              env:
+                  APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  APP_USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+                  APP_TOKEN: ${{ steps.app-token.outputs.token }}
+                  GH_REPOSITORY: ${{ github.repository }}
               run: |
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git config user.name "${APP_SLUG}[bot]"
+                  git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPOSITORY}.git"
                   git add -A
                   git diff --cached --quiet || (git commit -m "chore: fix enforcement of copyright on all files" && git push)
 
             - name: Check for changes
               if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' }}
-              uses: tj-actions/verify-changed-files@a1c6acee9df209257a246f2cc6ae8cb6581c1edf # v20.0.4
-              with:
-                  fail-if-changed: 'true'
+              run: |
+                  git add -A
+                  if ! git diff --cached --quiet; then
+                      echo "::error::Formatting changes were detected. Run the copyright script locally and commit the changes."
+                      echo "::group::Diff"
+                      git --no-pager diff --cached --color
+                      echo "::endgroup::"
+                      exit 1
+                  fi
 
     fix-code-style:
         name: Fix Code Style
@@ -74,13 +102,21 @@ jobs:
                   php-version: '8.4'
                   coverage: none
 
+            - name: Generate GitHub App Token
+              id: app-token
+              if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  permission-contents: write
+
             - name: Checkout code | Internal
               if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }} # zizmor: ignore[secrets-outside-env]
-                  persist-credentials: true # zizmor: ignore[artipacked] -- credentials needed for git push
+                  persist-credentials: false
 
             - name: Checkout code | External
               if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' }}
@@ -116,19 +152,39 @@ jobs:
             - name: Run Formatters
               run: composer format
 
+            - name: Get GitHub App User ID
+              id: get-user-id
+              if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
+              env:
+                  APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
             - name: Commit changes
               if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
+              env:
+                  APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  APP_USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+                  APP_TOKEN: ${{ steps.app-token.outputs.token }}
+                  GH_REPOSITORY: ${{ github.repository }}
               run: |
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git config user.name "${APP_SLUG}[bot]"
+                  git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPOSITORY}.git"
                   git add -A
                   git diff --cached --quiet || (git commit -m "chore: fix code style" && git push)
 
             - name: Check for changes
               if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' }}
-              uses: tj-actions/verify-changed-files@a1c6acee9df209257a246f2cc6ae8cb6581c1edf # v20.0.4
-              with:
-                  fail-if-changed: 'true'
+              run: |
+                  git add -A
+                  if ! git diff --cached --quiet; then
+                      echo "::error::Formatting changes were detected. Run 'composer format' locally and commit the changes."
+                      echo "::group::Diff"
+                      git --no-pager diff --cached --color
+                      echo "::endgroup::"
+                      exit 1
+                  fi
 
     lint:
         name: Lint

--- a/.github/workflows/update_yearly_copyright.yml
+++ b/.github/workflows/update_yearly_copyright.yml
@@ -19,11 +19,19 @@ jobs:
         timeout-minutes: 10
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  permission-contents: write
+                  permission-pull-requests: write
+
             - name: Checkout `main` Branch
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
-                  token: ${{ secrets.PAT }} # zizmor: ignore[secrets-outside-env]
-                  persist-credentials: true # zizmor: ignore[artipacked] -- credentials needed for git push
+                  persist-credentials: false
 
             - name: Set up Ruby
               uses: ruby/setup-ruby@6e5d382445ae5590b7449d8b3bc8cb1c2c27f617 # v1.317.0
@@ -31,13 +39,25 @@ jobs:
             - name: Run copyright script
               run: ruby ./copyright.rb
 
+            - name: Get GitHub App User ID
+              id: get-user-id
+              env:
+                  APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
             - name: Create Pull Request
               env:
-                  GH_TOKEN: ${{ secrets.PAT }} # zizmor: ignore[secrets-outside-env]
+                  APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  APP_USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+                  APP_TOKEN: ${{ steps.app-token.outputs.token }}
+                  GH_REPOSITORY: ${{ github.repository }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
                   BRANCH="update-yearly-copyright-$(date +%s)"
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git config user.name "${APP_SLUG}[bot]"
+                  git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPOSITORY}.git"
                   git checkout -b "${BRANCH}"
                   git add -A
                   git diff --cached --quiet && echo "No changes" && exit 0


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Switches to the CGBS Automation App for GitHub action authorization instead of a personally tied PAT.

Removes the usage of `tj-actions/verify-changed-files`, to replace it with standard git actions to make things easier and reduce supply-chain attack risk.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/common/blob/main/README.md#contributing).
