### PR TITLE
Fix migration-guidance targeting and reconcile the "never mix DDL/DML" rule

### DIFF
--- a/.ai/skills/laravel-best-practices/SKILL.md
+++ b/.ai/skills/laravel-best-practices/SKILL.md
@@ -63,7 +63,7 @@ Check sibling files, related controllers, models, or tests for established patte
 - Never modify migrations that have run in production
 - Add indexes in the migration (columns used in `WHERE`, `ORDER BY`, `JOIN`)
 - Reversible `down()` by default; forward-fix intentionally irreversible changes
-- One concern per migration — never mix DDL and DML
+- Keep each migration focused; mixing DDL and DML is expected for inseparable changes (rename-with-copy, flag activation) if transaction-wrapped — only split create-and-seed of a new table
 
 ### 5. Controllers & HTTP Endpoints → `rules/controllers.md`
 

--- a/.ai/skills/laravel-best-practices/rules/migrations.md
+++ b/.ai/skills/laravel-best-practices/rules/migrations.md
@@ -167,9 +167,17 @@ For intentionally irreversible migrations (e.g., destructive data backfills), le
 
 ## Keep Migrations Focused
 
-One concern per migration. Never mix DDL (schema changes) and DML (data manipulation).
+Keep each migration to a single concern. Mixing schema changes (DDL) and data changes (DML) is expected when they are **inseparable parts of the same change** — and when they are, wrap the whole `up()` (and `down()`) in a `DB::transaction` so a partial failure rolls back cleanly. See the `writing-data-migrations` skill for the data-change rules that apply.
 
-Incorrect (partial failure creates unrecoverable state):
+Legitimately mixed migrations include:
+
+- **Renaming or re-typing a column while preserving its data** — add the new column, `UPDATE` to copy the values across, then drop the old one. These steps cannot be split without leaving a broken intermediate state.
+- **Fixing dependent data after a structural change** — e.g. `Schema::rename` a table, then `UPDATE` the polymorphic `auditable_type` strings that referenced the old name.
+- **Activating a Feature Flag alongside the schema change it guards** — the zero-downtime convention activates the flag from the same migration that makes the change (see `managing-feature-flags`).
+
+The one split worth keeping is **creating a brand-new table and seeding it** — separate the `create` from the `insert`, because there is no atomicity requirement and the seed belongs in its own (often temporary `tmp_`) data migration.
+
+Incorrect (create and seed in one migration — split these):
 
 ```php
 public function up(): void

--- a/.ai/skills/writing-data-migrations/SKILL.md
+++ b/.ai/skills/writing-data-migrations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-data-migrations
-description: 'Use when writing or altering a Laravel migration that changes data (not only schema) in a Canyon GBS app — data back-fills, transformations, clean-ups, seeding, or activating a Feature Flag. Trigger whenever you create a migration with `make:migration` or `make:tmp-migration`, decide between a permanent and a temporary (`tmp_`) migration, need a migration to be idempotent and safe to re-run, add a required `down()`, or target the landlord versus tenant databases. Covers permanent-migration rules (DB facade only, no removable classes), temporary-migration rules and the `tmp_` prefix with its cleanup task, and running migrations. Do not use for: permission seeding (use `creating-permissions`), creating the Feature Flag class (use `managing-feature-flags`), cleanup task file mechanics (use `managing-cleanup-tasks`), or a migration that only changes schema (adding, modifying, or dropping columns or tables — even alongside a Feature Flag activation) with no data transformation — write those as plain, unconditional migrations with no existence guards.'
+description: 'Use when writing or altering a Laravel migration that changes data (not only schema) in a Canyon GBS app — data back-fills, transformations, clean-ups, seeding, or activating a Feature Flag. Trigger whenever you create a migration with `make:migration` or `make:tmp-migration`, decide between a permanent and a temporary (`tmp_`) migration, need a migration to be idempotent and safe to re-run, add a required `down()`, or target the landlord versus tenant databases. Covers permanent-migration rules (DB facade only, no removable classes), temporary-migration rules and the `tmp_` prefix with its cleanup task, and running migrations. Do not use for: permission seeding (use `creating-permissions`), creating the Feature Flag class (use `managing-feature-flags`), cleanup task file mechanics (use `managing-cleanup-tasks`), or a migration whose only substantive change is to the schema — adding, modifying, or dropping columns or tables, optionally activating a Feature Flag to guard that change — with no accompanying data back-fill or transformation; write those as plain, unconditional migrations with no existence guards.'
 user-invocable: false
 license: Elastic-2.0
 metadata:
@@ -46,7 +46,7 @@ Temporary migrations **may** use Eloquent and other removable classes because th
 ## Creating a migration
 
 ```bash
-php artisan make:migration backfill_order_totals
+php artisan make:migration convert_orders_reference_to_citext
 php artisan make:tmp-migration seed_default_settings_for_existing_tenants
 ```
 

--- a/.ai/skills/writing-data-migrations/SKILL.md
+++ b/.ai/skills/writing-data-migrations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-data-migrations
-description: 'Use when writing or altering a Laravel migration that changes data (not only schema) in a Canyon GBS app — data back-fills, transformations, clean-ups, seeding, or activating a Feature Flag. Trigger whenever you create a migration with `make:migration` or `make:tmp-migration`, decide between a permanent and a temporary (`tmp_`) migration, need a migration to be idempotent and safe to re-run, add a required `down()`, or target the landlord versus tenant databases. Covers permanent-migration rules (DB facade only, no removable classes), temporary-migration rules and the `tmp_` prefix with its cleanup task, and running migrations. Do not use for: permission seeding (use `creating-permissions`), creating the Feature Flag class (use `managing-feature-flags`), or cleanup task file mechanics (use `managing-cleanup-tasks`).'
+description: 'Use when writing or altering a Laravel migration that changes data (not only schema) in a Canyon GBS app — data back-fills, transformations, clean-ups, seeding, or activating a Feature Flag. Trigger whenever you create a migration with `make:migration` or `make:tmp-migration`, decide between a permanent and a temporary (`tmp_`) migration, need a migration to be idempotent and safe to re-run, add a required `down()`, or target the landlord versus tenant databases. Covers permanent-migration rules (DB facade only, no removable classes), temporary-migration rules and the `tmp_` prefix with its cleanup task, and running migrations. Do not use for: permission seeding (use `creating-permissions`), creating the Feature Flag class (use `managing-feature-flags`), cleanup task file mechanics (use `managing-cleanup-tasks`), or a migration that only changes schema (adding, modifying, or dropping columns or tables — even alongside a Feature Flag activation) with no data transformation — write those as plain, unconditional migrations with no existence guards.'
 user-invocable: false
 license: Elastic-2.0
 metadata:
@@ -26,7 +26,7 @@ Permanent migrations stay in the codebase indefinitely. When they include data c
 
 - **Do not reference classes that may later be removed** — no Eloquent models, no app facades. The only classes permitted are `Illuminate\Support\Facades\DB` and Feature Flag classes under `App\Features` (extending `App\Support\AbstractFeatureFlag`).
 - **Handle every possible SQL error** (e.g. `UniqueConstraintViolationException`) and wrap changes in a transaction so a failure cannot corrupt the query connection.
-- **Be idempotent** — check table and column existence, catch and handle SQL errors, and verify data state before changing it, so the migration can safely run more than once.
+- **Make _data_ writes idempotent by checking data state; keep _schema_ changes unconditional.** A permanent migration is recorded and runs exactly once per database, so "safe to re-run" / idempotency concerns only data writes that could be re-applied — never the schema. Before a data write, check the state of the data (e.g. `whereNull(...)`, match only the rows still needing conversion, skip already-migrated rows) so a re-run cannot duplicate or corrupt rows. Do **not** make a schema change conditional to "protect" a re-run: no `hasTable`/`hasColumn` existence guards, and never wrap a schema change in a `try`/`catch` that swallows "already exists" / "does not exist" errors — both silently skip a real problem. A migration owns the schema of the tables it manages: its schema changes are unconditional, and if the structure is not what you expect, let it fail loudly.
 - **Always include `down()`.** Production migrations run once and are not rolled back; if a shipped migration is wrong, write a new migration to fix it. `down()` is still required to support testing.
 
 ### Temporary migrations
@@ -46,7 +46,7 @@ Temporary migrations **may** use Eloquent and other removable classes because th
 ## Creating a migration
 
 ```bash
-php artisan make:migration add_status_column_to_orders_table
+php artisan make:migration backfill_order_totals
 php artisan make:tmp-migration seed_default_settings_for_existing_tenants
 ```
 


### PR DESCRIPTION
## Ticket(s) or GitHub Issue

No ticket — follow-up from reviewing AIDAPP-1303 (aidingapp #1350), where the shared `writing-data-migrations` skill mis-triggered on a pure schema-add-plus-flag migration and pushed `hasColumn`/`hasTable` guards that a reviewer flagged.

## Technical Description

Three agent-guidance corrections, all under `.ai/skills`:

**1. `writing-data-migrations` — fix targeting (`description`).** Added an explicit boundary so the skill no longer activates for a migration that *only* changes schema (add/modify/drop columns or tables — even alongside a Feature Flag activation) with no data transformation. Those are plain unconditional migrations and belong to `laravel-best-practices/rules/migrations.md`, which already models the no-guard pattern.

**2. `writing-data-migrations` — fix the idempotency rule (the load-bearing change).** The old bullet ("check table and column existence… verify data state") imported schema-guarding advice that no real data migration in the org actually uses (surveyed the `tmp_data_*` migrations in history — none use `hasColumn`/`hasTable`; they use data-state idempotency like `whereNull`). Rewrote it to: make **data writes** idempotent by checking data state; keep **schema changes unconditional** (a permanent migration runs exactly once, so idempotency concerns only data writes); explicitly forbid both `hasTable`/`hasColumn` guards and `try/catch` that swallows "already exists" / "does not exist" errors, since both silently skip a real problem.

**3. `laravel-best-practices/rules/migrations.md` — reconcile "never mix DDL/DML".** This rule contradicted the `writing-data-migrations` skill and, more importantly, actual sanctioned practice: mixed schema+data migrations are common and recent across repos (rename-with-copy, dependent-data fixes after a rename, flag activation) — all transaction-wrapped, which neutralises the old rule's rationale. Reworded to allow mixing for inseparable changes in one transaction, keeping only the create-a-new-table-and-seed-it split. The index entry in `laravel-best-practices/SKILL.md` §4 was updated in the same commit to match.

**Validation (RED/GREEN per `writing-skills`).** Each change was pressure-tested with fresh single-shot agents (5+ reps, no-guidance control, every match read manually):

- **Schema-guard test:** control 5/5 and old-wording 5/5 added `hasColumn` guards; the shipped wording gives **0/5 `hasColumn`, 0/5 catch-swallow**. This took two refactor cycles — the first fix merely made agents swap `hasColumn` for a `catch "already exists"` swallow, which the final wording explicitly closes.
- **Mixing test:** old wording 5/5 split an inseparable retype-with-copy into 3 migrations (broken intermediate state); shipped wording 5/5 produce one `DB::transaction`-wrapped migration.

## Any deployment steps required?

No. Consuming apps pick the changes up on their next `composer update` + `common:publish`.

## Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No. Documentation / agent-guidance only.
