### PR TITLE
Hide convention and guideline skills from the slash-command menu

### DIFF
--- a/.ai/skills/archiving-records/SKILL.md
+++ b/.ai/skills/archiving-records/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: archiving-records
 description: 'Use when adding or working with archiving in a Canyon GBS app — a soft alternative to deletion using an `archived_at` timestamp where archived records are INCLUDED in queries by default (unlike SoftDeletes). Trigger whenever you add the `CanBeArchived` trait to a model, add an `archived_at` column, use archive()/unarchive()/isArchived() or the withoutArchived / onlyArchived / withoutArchivedAndUnused query scopes, define used()/isUsed() for archived-but-still-used records, wire the Filament ArchiveAction / ArchiveBulkAction, or handle archiving model events and authorization. Do not use for: Laravel SoftDeletes (a different feature), or writing tests for archiving (use `writing-tests`).'
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs

--- a/.ai/skills/authoring-agent-guidance/SKILL.md
+++ b/.ai/skills/authoring-agent-guidance/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: authoring-agent-guidance
 description: "Use when creating, editing, or reviewing this project's agent guidance — Laravel Boost guidelines (.ai/guidelines/**/*.blade.php), skills (.ai/skills/<name>/SKILL.md), the boost.json / mcp.json config, or the canyongbs/common publish and override system. Trigger whenever someone asks to add or change a guideline or skill, tweak what Boost injects into AGENTS.md, exclude a bundled/third-party guideline or skill, wire up an override (boost.override.json, .vscode/mcp.override.json, .ai/overrides/**), or understand how common:publish assembles a consuming app's guidance. Applies both inside the common package itself and inside apps that depend on canyongbs/common. Do not use for ordinary Laravel feature code, or for writing automated tests (use the writing-tests skill)."
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs
@@ -67,11 +68,16 @@ Skills are on-demand knowledge modules loaded when their `description` matches t
     ---
     name: <kebab-case-name> # must match the folder name
     description: 'Use when …' # the activation trigger — see below
+    user-invocable: false # for model-only skills; hides from the `/` menu (see invocation axes below)
     license: Elastic-2.0
     metadata:
         author: canyongbs
     ---
     ```
+- **Two independent invocation axes — set them by who the skill is for.** `user-invocable` (default `true`) controls whether the skill shows in the `/` slash-command menu; `disable-model-invocation` (default `false`) controls whether the agent may auto-load it by `description` match. Choose per skill:
+    - _Model-only convention/guideline skill_ (the common case today — the agent loads it automatically and no human runs it): set `user-invocable: false` and leave model invocation on. This is why every current common skill sets it.
+    - _Human-invoked "run this" skill_ (a person deliberately triggers it via `/` and the model should **not** pull it in on its own): keep `user-invocable: true` and set `disable-model-invocation: true`. That opts the skill out of automatic `description`-match loading, leaving the `/` slash command as its only trigger.
+    - A skill may of course be both model- and human-invocable — then set neither. Decide deliberately rather than copying a sibling.
 - **The `description` is the most important line.** It decides whether the agent activates the skill. Write it as trigger conditions: when to use, what tasks/files it covers, and explicit "do not use for …" boundaries to avoid overlap with sibling skills. Study `writing-tests` and `local-common-development` for the expected shape.
 - No `boost.json` entry is needed for a common-authored skill — presence in `.ai/skills/` is what publishes and activates it. The `boost.json` `skills` array is only for enabling **Boost's bundled** skills.
 - To drop a common-authored skill from a **single** app, add its `name` to `boost.skills.exclude` — the same exclude list used for Boost's bundled skills. `common:publish` skips copying any common skill whose name appears there, so an app can opt out of shared skills it does not need (for example, an alpha app that does not yet use feature flags).

--- a/.ai/skills/code-style-and-static-analysis/SKILL.md
+++ b/.ai/skills/code-style-and-static-analysis/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: code-style-and-static-analysis
 description: "Use when running or fixing code style and static analysis for a Canyon GBS app — the `composer format` / `lint` / `checks` scripts and the tools behind them (PHP CS Fixer, Prettier including Blade, PHPStan/Larastan, Rector, Laravel IDE Helper). Trigger whenever you need to format code, resolve a style or static-analysis failure, run the pre-completion checks before finishing a change, or regenerate IDE helper files after model or schema changes. Do not use for: writing tests (use `writing-tests`) or authoring guidelines and skills (use `authoring-agent-guidance`). For editor/IDE setup, see the app's local-setup docs rather than this skill."
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs

--- a/.ai/skills/creating-permissions/SKILL.md
+++ b/.ai/skills/creating-permissions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: creating-permissions
 description: 'Use when creating, seeding, renaming, or deleting Spatie Laravel-permission permissions in a Canyon GBS app via a permission migration. Trigger whenever you add permissions for a model or feature, run `make:permission-migration`, use the `CanModifyPermissions` trait (createPermissions / deletePermissions / renamePermissions / renamePermissionGroups), choose a permission group, or decide which of the allowed permission names a model needs. Covers the `seed_permissions_` naming, permission groups, the allowed permission-name format, guards, and the `--module` flag. Do not use for: general data migrations (use `writing-data-migrations`), or writing the policies / authorization checks that consume the permissions.'
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs

--- a/.ai/skills/handling-file-uploads/SKILL.md
+++ b/.ai/skills/handling-file-uploads/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: handling-file-uploads
 description: 'Use when storing, uploading, or serving user files and images in a Canyon GBS app with Spatie Media Library — adding a file/image upload, defining media collections and conversions, choosing the S3 disk (private vs public), or outputting a stored image (temporary URLs, WebP conversions). Trigger whenever a model implements `HasMedia`, you register a media collection or conversion, add a Filament `SpatieMediaLibraryFileUpload`, or output a stored file/image. Do not use for: static images shipped with the app (logos/illustrations via Vite — see the `assets` rule in the `laravel-best-practices` skill), attaching files to settings pages (use `managing-settings` for the wiring), or writing tests (use `writing-tests`).'
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs

--- a/.ai/skills/laravel-best-practices/SKILL.md
+++ b/.ai/skills/laravel-best-practices/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: laravel-best-practices
 description: 'Apply this skill whenever writing, reviewing, or refactoring Laravel PHP code. This includes creating or modifying models, relationships, migrations, policies, observers, jobs, invokable controllers, Action and service classes, and Eloquent queries. Triggers for N+1 and query performance issues, caching strategies, authorization and security patterns, choosing between an observer and an action, writing model attributes and relationships without mass assignment, queue and job configuration, HTTP client usage, database and PostgreSQL schema conventions (UUID keys, citext, unique indexes, soft deletes), configuration and environment access, static frontend assets (Vite), naming and code-style conventions, and architectural decisions. Also use for Laravel code reviews and refactoring existing Laravel code to follow best practices. Covers any task involving Laravel backend PHP code patterns.'
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs

--- a/.ai/skills/local-common-development/SKILL.md
+++ b/.ai/skills/local-common-development/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: local-common-development
 description: "Use when an app ticket requires changes to the canyongbs/common package and you need to work against a local, editable checkout of common instead of the released version. Trigger whenever a change must be made in common (guidelines, skills, migrations, models, Filament resources, enums, console commands, health checks, rector sets, or any src/ code) while developing or testing inside a consuming app. Covers linking common into an app via a Composer path repository with symlink, bind-mounting the local checkout into the app's Docker containers so the symlink resolves, verifying the symlink, editing common with changes reflected live, republishing common's AI content, and safely unlinking to restore the released version before committing the app. Do not trigger for changes that live entirely inside the app, or for editing an app's own app-modules."
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs

--- a/.ai/skills/managing-cleanup-tasks/SKILL.md
+++ b/.ai/skills/managing-cleanup-tasks/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: managing-cleanup-tasks
 description: 'Use when creating, updating, or completing a cleanup task file in `.cleanup-tasks/` — the tracked record of post-deployment cleanup work (Feature Flags to remove, temporary `tmp_` migrations to delete, and other follow-up). Trigger whenever you run or reason about `make:cleanup`, `make:ff`, or `make:tmp-migration` and their cleanup prompts, add an entry to a cleanup task, write an inline `TODO: Cleanup Task` comment, or perform the cleanup after a deploy. Covers the file format and sections, the three entry types, the inline comment convention (stable root plus unique tag), and what must NOT go in the Additional Cleanup section. Do not use for: creating the Feature Flag class (use `managing-feature-flags`) or writing the migration (use `writing-data-migrations`); this skill is about the cleanup tracking itself.'
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs

--- a/.ai/skills/managing-feature-flags/SKILL.md
+++ b/.ai/skills/managing-feature-flags/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: managing-feature-flags
 description: 'Use when creating, activating, gating code behind, or removing a class-based Feature Flag in a Canyon GBS app — Laravel Pennant flags under `App\Features` extending `App\Support\AbstractFeatureFlag`, generated with `make:ff`. Trigger whenever you introduce a schema or data change that code depends on and must be guarded for zero-downtime deploys, add or edit an `active()` / `resolve()` check, activate a flag inside a migration, or clean up a flag after a deployment. Covers the make:ff command and its cleanup-task prompt, the resolve() default, activation-in-migration patterns, the active/inactive code split, and documenting non-obvious flag removals with inline cleanup comments. Do not use for: the mechanics of cleanup task files themselves (use `managing-cleanup-tasks`), writing the migrations that carry the change (use `writing-data-migrations`), subscription/license feature ADDON gating (app-specific), or Pennant scoped/config-driven flags.'
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs

--- a/.ai/skills/managing-settings/SKILL.md
+++ b/.ai/skills/managing-settings/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: managing-settings
 description: 'Use when creating or changing application settings in a Canyon GBS app built on spatie/laravel-settings — adding a settings class or property, writing a settings migration, choosing the settings group or repository, encrypting settings, building a Filament `SettingsPage`, or attaching an uploaded file to a settings page. Trigger whenever you add or edit a class extending Spatie `Settings`, a `SettingsMigration`, a Filament `SettingsPage`, or the `SettingsProperty` media bridge. Do not use for: generic config files / env access (see the `config` rule in the `laravel-best-practices` skill), general file uploads not tied to settings (use `handling-file-uploads`), or writing tests (use `writing-tests`).'
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs

--- a/.ai/skills/structuring-filament-code/SKILL.md
+++ b/.ai/skills/structuring-filament-code/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: structuring-filament-code
 description: "Use when writing or reviewing Filament v4+ code in a Canyon GBS app and want it maintainable and small — organizing a resource's form, infolist, and table into separate `configure()` classes; extracting fields, columns, filters, or actions into their own classes; deciding between a static `make()` factory and extending a component base class; or splitting a schema per page instead of branching by operation/context. Trigger whenever a Filament schema/table/action definition grows beyond a few lines or gains a complex closure, when adding a resource page schema, when you add record-dependent logic to a `delete`/`restore`/`forceDelete` policy method and must authorize individual records on the model's Filament bulk actions, or when you see per-page branching (`hiddenOn`/`visibleOn`/`disabledOn`, `$operation`, `$livewire instanceof`). Do not use for: non-Filament PHP (use `laravel-best-practices`), Filament file uploads (use `handling-file-uploads`), settings-page wiring (use `managing-settings`), or writing tests (use `writing-tests`)."
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs

--- a/.ai/skills/writing-data-migrations/SKILL.md
+++ b/.ai/skills/writing-data-migrations/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: writing-data-migrations
 description: 'Use when writing or altering a Laravel migration that changes data (not only schema) in a Canyon GBS app — data back-fills, transformations, clean-ups, seeding, or activating a Feature Flag. Trigger whenever you create a migration with `make:migration` or `make:tmp-migration`, decide between a permanent and a temporary (`tmp_`) migration, need a migration to be idempotent and safe to re-run, add a required `down()`, or target the landlord versus tenant databases. Covers permanent-migration rules (DB facade only, no removable classes), temporary-migration rules and the `tmp_` prefix with its cleanup task, and running migrations. Do not use for: permission seeding (use `creating-permissions`), creating the Feature Flag class (use `managing-feature-flags`), or cleanup task file mechanics (use `managing-cleanup-tasks`).'
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs

--- a/.ai/skills/writing-tests/SKILL.md
+++ b/.ai/skills/writing-tests/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: writing-tests
 description: 'Use this skill whenever writing, editing, fixing, or refactoring automated tests in a Canyon GBS Laravel application — including tests for Filament resources, pages, relation managers, actions, jobs, models, enums, console commands, and HTTP controllers. Trigger whenever a test is created or changed, a test breaks after a code change, assertions or datasets are added, or PHPUnit is converted to Pest. Covers test file placement and naming (mirroring the source namespace), one-file-per-class organization, describe() grouping, it()/expect() style, datasets, Filament Livewire testing helpers, Worksome RequestFactory usage, shared Pest.php helpers, and Pest 4 features. This is the single authoritative testing skill for these apps — it supersedes generic Pest guidance. Do not use for non-test PHP code, factories that are not request factories, seeders, or migrations.'
+user-invocable: false
 license: Elastic-2.0
 metadata:
     author: canyongbs


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

N/A

### Technical Description

All of `common`'s authored skills under `.ai/skills/` are model-loaded convention/guideline modules — the agent activates them automatically by `description` match, and no human runs them directly. They were nonetheless showing up in the `/` slash-command menu.

This sets `user-invocable: false` ([VS Code Agent Skills frontmatter](https://code.visualstudio.com/docs/agent-customization/agent-skills#_header-required), default `true`) on all 13 common skills, hiding them from the `/` menu while leaving automatic model invocation intact. Third-party Boost-bundled skills are untouched.

`authoring-agent-guidance` is also updated to document the two independent invocation axes so future skills are authored correctly:

- `user-invocable: false` — model-only skill; hidden from the `/` menu (current default for common's skills).
- `disable-model-invocation: true` — opts a skill out of automatic loading so a human `/` call is its only trigger (for genuinely human-invoked skills).

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No
