### PR TITLE
[Chore]: Add ActionClassesMustBeInvokable rule and related tests

### DIFF
--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -16,6 +16,13 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: CanyonGBS\Common\Rules\ActionClassesMustBeInvokable\ActionClassesMustBeInvokableRule
+        arguments:
+            includePatterns: %actionNamespaceIncludePatterns%
+            excludePatterns: %actionNamespaceExcludePatterns%
+        tags:
+            - phpstan.rules.rule
+    -
         class: CanyonGBS\Common\Rules\FeatureFlagConventions\FeatureFlagConventionsRule
         arguments:
             baseClasses: %featureFlagBaseClasses%
@@ -64,11 +71,19 @@ services:
             - phpstan.rules.rule
 
 parameters:
+    actionNamespaceIncludePatterns:
+        - App\Actions
+        - *\*\Actions
+    actionNamespaceExcludePatterns:
+        - *\Filament\Actions
+        - *\Filament\Actions\*
     featureFlagBaseClasses:
         - App\Support\AbstractFeatureFlag
         - App\Support\LandlordAbstractFeatureFlag
     featuresNamespace: App\Features
 
 parametersSchema:
+    actionNamespaceIncludePatterns: listOf(string())
+    actionNamespaceExcludePatterns: listOf(string())
     featureFlagBaseClasses: listOf(string())
     featuresNamespace: string()

--- a/src/Rules/ActionClassesMustBeInvokable/ActionClassesMustBeInvokableRule.php
+++ b/src/Rules/ActionClassesMustBeInvokable/ActionClassesMustBeInvokableRule.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\ActionClassesMustBeInvokable;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use ReflectionMethod;
+
+/**
+ * Enforces Laravel action-pattern classes to expose a single public invocation entrypoint.
+ *
+ * Classes matched by configured include patterns (and not matched by exclude patterns) must:
+ *
+ * - define a public "__invoke" method;
+ * - not expose any other public methods except "__construct".
+ *
+ * Private and protected helper methods are allowed.
+ *
+ * Abstract classes are ignored.
+ *
+ * @implements Rule<InClassNode>
+ */
+class ActionClassesMustBeInvokableRule implements Rule
+{
+    public const string MISSING_INVOKE_ERROR_MESSAGE = 'Action class "%s" must define a public "__invoke" method. Action classes should be accessed via invocation and keep other behavior in private/protected helpers.';
+
+    public const string DISALLOWED_PUBLIC_METHOD_ERROR_MESSAGE = 'Action class "%s" defines disallowed public method "%s". Only "__invoke" and "__construct" may be public on action classes.';
+
+    /**
+     * @param list<string> $includePatterns
+     * @param list<string> $excludePatterns
+     */
+    public function __construct(
+        private array $includePatterns,
+        private array $excludePatterns,
+    ) {
+    }
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return list<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if (! $classReflection->isClass() || $classReflection->isAbstract()) {
+            return [];
+        }
+
+        $className = $classReflection->getName();
+
+        if (! $this->isActionClass($className)) {
+            return [];
+        }
+
+        $errors = [];
+
+        if (! $classReflection->hasNativeMethod('__invoke') || ! $classReflection->getNativeMethod('__invoke')->isPublic()) {
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                self::MISSING_INVOKE_ERROR_MESSAGE,
+                $className,
+            ))
+                ->identifier('Common.actionClassMustBeInvokable')
+                ->build();
+        }
+
+        $nativeReflection = $classReflection->getNativeReflection();
+
+        foreach ($nativeReflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            $methodName = $method->getName();
+
+            if (in_array($methodName, ['__invoke', '__construct'], true)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                self::DISALLOWED_PUBLIC_METHOD_ERROR_MESSAGE,
+                $className,
+                $methodName,
+            ))
+                ->identifier('Common.actionClassHasDisallowedPublicMethod')
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function isActionClass(string $className): bool
+    {
+        $namespace = $this->extractNamespace($className);
+
+        if ($namespace === null) {
+            return false;
+        }
+
+        if (! $this->matchesAnyPattern($namespace, $this->includePatterns)) {
+            return false;
+        }
+
+        return ! $this->matchesAnyPattern($namespace, $this->excludePatterns);
+    }
+
+    private function extractNamespace(string $className): ?string
+    {
+        $position = strrpos($className, '\\');
+
+        if ($position === false) {
+            return null;
+        }
+
+        return substr($className, 0, $position);
+    }
+
+    /**
+     * @param list<string> $patterns
+     */
+    private function matchesAnyPattern(string $namespace, array $patterns): bool
+    {
+        foreach ($patterns as $pattern) {
+            if ($this->matchesPattern($namespace, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function matchesPattern(string $namespace, string $pattern): bool
+    {
+        $normalizedPattern = trim($pattern, '\\');
+
+        if ($normalizedPattern === '') {
+            return false;
+        }
+
+        $segments = explode('\\', $normalizedPattern);
+        $regexSegments = array_map(static function (string $segment): string {
+            return str_replace('\\*', '[^\\\\]*', preg_quote($segment, '#'));
+        }, $segments);
+
+        $regex = '#^' . implode('\\\\', $regexSegments) . '(?:\\\\|$)#';
+
+        return preg_match($regex, $namespace) === 1;
+    }
+}

--- a/src/Rules/ActionClassesMustBeInvokable/ActionClassesMustBeInvokableRule.php
+++ b/src/Rules/ActionClassesMustBeInvokable/ActionClassesMustBeInvokableRule.php
@@ -71,8 +71,7 @@ class ActionClassesMustBeInvokableRule implements Rule
     public function __construct(
         private array $includePatterns,
         private array $excludePatterns,
-    ) {
-    }
+    ) {}
 
     /**
      * @return class-string<Node>

--- a/tests/PHPStan/ActionClassesMustBeInvokableTest.php
+++ b/tests/PHPStan/ActionClassesMustBeInvokableTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('does not report action classes that only expose __invoke publicly', function () {
+    $result = runPhpStanOnActionClassFixture('tests/PHPStan/Fixtures/ActionInvokableFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report valid action classes.\nOutput: {$result['output']}");
+});
+
+it('reports action classes missing __invoke and exposing execute publicly', function () {
+    $result = runPhpStanOnActionClassFixture('tests/PHPStan/Fixtures/ActionMissingInvokeFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.actionClassMustBeInvokable');
+    expect($result['output'])->toContain('Common.actionClassHasDisallowedPublicMethod');
+});
+
+it('reports action classes that expose extra public methods', function () {
+    $result = runPhpStanOnActionClassFixture('tests/PHPStan/Fixtures/ActionWithExtraPublicMethodFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.actionClassHasDisallowedPublicMethod');
+    expect($result['output'])->not->toContain('Common.actionClassMustBeInvokable');
+});
+
+it('does not report classes outside action namespaces', function () {
+    $result = runPhpStanOnActionClassFixture('tests/PHPStan/Fixtures/NonActionOutsideNamespaceFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report classes outside action namespaces.\nOutput: {$result['output']}");
+});
+
+it('does not report abstract action classes', function () {
+    $result = runPhpStanOnActionClassFixture('tests/PHPStan/Fixtures/AbstractActionFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report abstract action classes.\nOutput: {$result['output']}");
+});
+
+it('reports modular action namespaces matched by wildcard include patterns', function () {
+    $result = runPhpStanOnActionClassFixture('tests/PHPStan/Fixtures/ModularActionMissingInvokeFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect($result['output'])->toContain('Common.actionClassMustBeInvokable');
+    expect($result['output'])->toContain('Common.actionClassHasDisallowedPublicMethod');
+});
+
+it('does not report classes in Filament actions namespaces excluded by default', function () {
+    $result = runPhpStanOnActionClassFixture('tests/PHPStan/Fixtures/FilamentActionExcludedFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report classes in excluded Filament action namespaces.\nOutput: {$result['output']}");
+});
+
+it('does not report classes in nested Filament actions namespaces excluded by default', function () {
+    $result = runPhpStanOnActionClassFixture('tests/PHPStan/Fixtures/NestedFilamentActionExcludedFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report classes in nested excluded Filament action namespaces.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnActionClassFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/action-classes-must-be-invokable.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}

--- a/tests/PHPStan/Configs/action-classes-must-be-invokable.neon
+++ b/tests/PHPStan/Configs/action-classes-must-be-invokable.neon
@@ -1,0 +1,15 @@
+parameters:
+    level: 6
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\ActionClassesMustBeInvokable\ActionClassesMustBeInvokableRule
+        arguments:
+            includePatterns:
+                - App\Actions
+                - *\*\Actions
+            excludePatterns:
+                - *\Filament\Actions
+                - *\Filament\Actions\*
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Fixtures/AbstractActionFixture.php
+++ b/tests/PHPStan/Fixtures/AbstractActionFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Actions;
 
 abstract class AbstractActionFixture

--- a/tests/PHPStan/Fixtures/AbstractActionFixture.php
+++ b/tests/PHPStan/Fixtures/AbstractActionFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Actions;
+
+abstract class AbstractActionFixture
+{
+    public function execute(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/ActionInvokableFixture.php
+++ b/tests/PHPStan/Fixtures/ActionInvokableFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Actions;
 
 class ActionInvokableFixture

--- a/tests/PHPStan/Fixtures/ActionInvokableFixture.php
+++ b/tests/PHPStan/Fixtures/ActionInvokableFixture.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Actions;
+
+class ActionInvokableFixture
+{
+    public function __invoke(): void
+    {
+    }
+
+    protected function helper(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/ActionMissingInvokeFixture.php
+++ b/tests/PHPStan/Fixtures/ActionMissingInvokeFixture.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Actions;
+
+class ActionMissingInvokeFixture
+{
+    public function execute(): void {}
+}

--- a/tests/PHPStan/Fixtures/ActionMissingInvokeFixture.php
+++ b/tests/PHPStan/Fixtures/ActionMissingInvokeFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Actions;
 
 class ActionMissingInvokeFixture

--- a/tests/PHPStan/Fixtures/ActionWithExtraPublicMethodFixture.php
+++ b/tests/PHPStan/Fixtures/ActionWithExtraPublicMethodFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Actions;
 
 class ActionWithExtraPublicMethodFixture

--- a/tests/PHPStan/Fixtures/ActionWithExtraPublicMethodFixture.php
+++ b/tests/PHPStan/Fixtures/ActionWithExtraPublicMethodFixture.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Actions;
+
+class ActionWithExtraPublicMethodFixture
+{
+    public function __invoke(): void
+    {
+    }
+
+    public function execute(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/FilamentActionExcludedFixture.php
+++ b/tests/PHPStan/Fixtures/FilamentActionExcludedFixture.php
@@ -34,7 +34,7 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Portal\Filament\Actions;
+namespace App\Filament\Actions;
 
 class FilamentActionExcludedFixture
 {

--- a/tests/PHPStan/Fixtures/FilamentActionExcludedFixture.php
+++ b/tests/PHPStan/Fixtures/FilamentActionExcludedFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AidingApp\Portal\Filament\Actions;
+
+class FilamentActionExcludedFixture
+{
+    public function execute(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/FilamentActionExcludedFixture.php
+++ b/tests/PHPStan/Fixtures/FilamentActionExcludedFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AidingApp\Portal\Filament\Actions;
 
 class FilamentActionExcludedFixture

--- a/tests/PHPStan/Fixtures/ModularActionMissingInvokeFixture.php
+++ b/tests/PHPStan/Fixtures/ModularActionMissingInvokeFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AidingApp\Portal\Actions;
+
+class ModularActionMissingInvokeFixture
+{
+    public function execute(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/ModularActionMissingInvokeFixture.php
+++ b/tests/PHPStan/Fixtures/ModularActionMissingInvokeFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AidingApp\Portal\Actions;
 
 class ModularActionMissingInvokeFixture

--- a/tests/PHPStan/Fixtures/NestedFilamentActionExcludedFixture.php
+++ b/tests/PHPStan/Fixtures/NestedFilamentActionExcludedFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AidingApp\Portal\Filament\Actions\Tables;
+
+class NestedFilamentActionExcludedFixture
+{
+    public function execute(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/NestedFilamentActionExcludedFixture.php
+++ b/tests/PHPStan/Fixtures/NestedFilamentActionExcludedFixture.php
@@ -34,7 +34,7 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Portal\Filament\Actions\Tables;
+namespace App\Filament\Actions\Tables;
 
 class NestedFilamentActionExcludedFixture
 {

--- a/tests/PHPStan/Fixtures/NestedFilamentActionExcludedFixture.php
+++ b/tests/PHPStan/Fixtures/NestedFilamentActionExcludedFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AidingApp\Portal\Filament\Actions\Tables;
 
 class NestedFilamentActionExcludedFixture

--- a/tests/PHPStan/Fixtures/NonActionOutsideNamespaceFixture.php
+++ b/tests/PHPStan/Fixtures/NonActionOutsideNamespaceFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Services;
+
+class NonActionOutsideNamespaceFixture
+{
+    public function execute(): void
+    {
+    }
+}

--- a/tests/PHPStan/Fixtures/NonActionOutsideNamespaceFixture.php
+++ b/tests/PHPStan/Fixtures/NonActionOutsideNamespaceFixture.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Services;
 
 class NonActionOutsideNamespaceFixture


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Adds the `ActionClassesMustBeInvokable` PHPStan rule to make it so actions must only have one public method and it should be `__invoke` so that they are invokable classes.

Excludes Filament "Action" classes.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/common/blob/main/README.md#contributing).
