### PR TITLE
[Chore]: Add NoAssertSeeRule to flag assertSee assertions in tests

### DIFF
--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -42,6 +42,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: CanyonGBS\Common\Rules\NoAssertSee\NoAssertSeeRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: CanyonGBS\Common\Rules\NoBlueprintAfterGrouping\NoBlueprintAfterGroupingRule
         tags:
             - phpstan.rules.rule

--- a/src/Rules/NoAssertSee/NoAssertSeeRule.php
+++ b/src/Rules/NoAssertSee/NoAssertSeeRule.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace CanyonGBS\Common\Rules\NoAssertSee;
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Testing\TestComponent;
+use Illuminate\Testing\TestResponse;
+use Illuminate\Testing\TestView;
+use Livewire\Component;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Flags calls to the assertSee family of test assertions (Livewire's testable, Laravel's
+ * TestResponse/TestView/TestComponent, and Mailable). These only prove the given text appears
+ * somewhere in the rendered output, not that it appears where the test expects, so they can pass
+ * even when the feature under test is broken. Prefer a more precise assertion (e.g. asserting
+ * component/view state, a scoped selector, or the specific structure produced). If you are
+ * certain you specifically need one of these assertions, the rule can be silenced with a
+ * specific inline ignore.
+ *
+ * Only flags calls made on a receiver known to actually carry these testing assertions, so
+ * unrelated classes/namespaces that happen to define a same-named method are left alone.
+ *
+ * @implements Rule<MethodCall>
+ */
+class NoAssertSeeRule implements Rule
+{
+    public const string ERROR_MESSAGE = 'Avoid assertSee() and its alternatives: they only prove the text appears somewhere in the rendered output, not that it appears where the test actually expects it, so they can pass even when the feature under test is broken. Prefer a more precise assertion (e.g. asserting component/view state, a scoped selector, or the specific structure produced). If you are certain you specifically need this assertion, add an inline ignore for this rule (// @phpstan-ignore Common.noAssertSee).';
+
+    /**
+     * @var list<string>
+     */
+    private const array BANNED_METHODS = [
+        'assertSee',
+        'assertSeeText',
+        'assertSeeHtml',
+        'assertSeeHtmlInOrder',
+        'assertSeeInOrder',
+        'assertSeeTextInOrder',
+        'assertDontSee',
+        'assertDontSeeText',
+        'assertDontSeeHtml',
+        'assertSeeIn',
+        'assertDontSeeIn',
+        'assertSeeInHtml',
+        'assertDontSeeInHtml',
+        'assertSeeInText',
+        'assertDontSeeInText',
+        'assertSeeInOrderInHtml',
+        'assertSeeInOrderInText',
+    ];
+
+    /**
+     * Classes that actually carry the assertSee-family assertions we ban. `Laravel\Dusk\Browser`
+     * is referenced as a plain string since Dusk is not a dependency of every consuming app; the
+     * class does not need to exist for an ObjectType comparison against it to work.
+     *
+     * @var list<string>
+     */
+    private const array ALLOWED_RECEIVER_CLASSES = [
+        TestResponse::class,
+        TestView::class,
+        TestComponent::class,
+        Mailable::class,
+        Component::class,
+        'Laravel\Dusk\Browser',
+    ];
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     *
+     * @return array<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        if (! in_array($node->name->toString(), self::BANNED_METHODS, true)) {
+            return [];
+        }
+
+        if (! $this->isKnownAssertionReceiver($node, $scope)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                ->identifier('Common.noAssertSee')
+                ->build(),
+        ];
+    }
+
+    private function isKnownAssertionReceiver(MethodCall $node, Scope $scope): bool
+    {
+        $calledOnType = $scope->getType($node->var);
+
+        $allowedType = TypeCombinator::union(
+            ...array_map(static fn (string $class): ObjectType => new ObjectType($class), self::ALLOWED_RECEIVER_CLASSES)
+        );
+
+        return $allowedType->isSuperTypeOf($calledOnType)->yes();
+    }
+}

--- a/tests/PHPStan/Configs/no-assert-see.neon
+++ b/tests/PHPStan/Configs/no-assert-see.neon
@@ -1,0 +1,10 @@
+parameters:
+    level: 6
+    ignoreErrors:
+        - identifier: missingType.generics
+
+services:
+    -
+        class: CanyonGBS\Common\Rules\NoAssertSee\NoAssertSeeRule
+        tags:
+            - phpstan.rules.rule

--- a/tests/PHPStan/Fixtures/AssertSeeAllowedFixture.php
+++ b/tests/PHPStan/Fixtures/AssertSeeAllowedFixture.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+class UnrelatedClassWithAssertSeeMethod
+{
+    public function assertSee(string $value): void
+    {
+        // Not a test assertion, just a same-named method on an unrelated class.
+    }
+}
+
+class AssertSeeAllowedFixtureTest
+{
+    public function test(\Illuminate\Testing\TestResponse $response, UnrelatedClassWithAssertSeeMethod $unrelated): void
+    {
+        $response->assertOk();
+        $response->assertViewHas('posts');
+
+        $unrelated->assertSee('foo');
+    }
+}

--- a/tests/PHPStan/Fixtures/AssertSeeFixture.php
+++ b/tests/PHPStan/Fixtures/AssertSeeFixture.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+class AssertSeeFixtureTest
+{
+    public function test(
+        \Illuminate\Testing\TestResponse $response,
+        \Illuminate\Mail\Mailable $mailable,
+        \Livewire\Component $component,
+    ): void {
+        $response->assertSee('foo');
+        $response->assertSeeText('foo');
+        $response->assertSeeHtml('<p>foo</p>');
+        $response->assertSeeHtmlInOrder(['<p>foo</p>', '<p>bar</p>']);
+        $response->assertSeeInOrder(['foo', 'bar']);
+        $response->assertSeeTextInOrder(['foo', 'bar']);
+        $response->assertDontSee('foo');
+        $response->assertDontSeeText('foo');
+        $response->assertDontSeeHtml('<p>foo</p>');
+
+        $mailable->assertSeeInHtml('foo');
+        $mailable->assertDontSeeInHtml('foo');
+        $mailable->assertSeeInText('foo');
+        $mailable->assertDontSeeInText('foo');
+        $mailable->assertSeeInOrderInHtml(['foo', 'bar']);
+        $mailable->assertSeeInOrderInText(['foo', 'bar']);
+
+        $component->assertSeeIn('@foo', 'bar');
+        $component->assertDontSeeIn('@foo', 'bar');
+    }
+}

--- a/tests/PHPStan/Fixtures/AssertSeeIgnoredFixture.php
+++ b/tests/PHPStan/Fixtures/AssertSeeIgnoredFixture.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+class AssertSeeIgnoredFixtureTest
+{
+    public function test(\Illuminate\Testing\TestResponse $response): void
+    {
+        // @phpstan-ignore Common.noAssertSee
+        $response->assertSee('foo');
+    }
+}

--- a/tests/PHPStan/NoAssertSeeTest.php
+++ b/tests/PHPStan/NoAssertSeeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS LLC. All rights reserved.
+
+    Canyon GBS Common is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/common/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Canyon GBS Common are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+it('reports calls to the assertSee family of methods', function () {
+    $result = runPhpStanOnNoAssertSeeFixture('tests/PHPStan/Fixtures/AssertSeeFixture.php');
+
+    expect($result['exitCode'])->not->toBe(0);
+    expect(substr_count($result['output'], '"identifier":"Common.noAssertSee"'))->toBe(17);
+});
+
+it('does not report assertSeeLivewire or unrelated assertions', function () {
+    $result = runPhpStanOnNoAssertSeeFixture('tests/PHPStan/Fixtures/AssertSeeAllowedFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should not report assertSeeLivewire/assertDontSeeLivewire or unrelated assertions.\nOutput: {$result['output']}");
+});
+
+it('allows assertSee() calls silenced with a specific inline ignore', function () {
+    $result = runPhpStanOnNoAssertSeeFixture('tests/PHPStan/Fixtures/AssertSeeIgnoredFixture.php');
+
+    expect($result['exitCode'])->toBe(0, "PHPStan should respect the inline ignore for assertSee() calls.\nOutput: {$result['output']}");
+});
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runPhpStanOnNoAssertSeeFixture(string $filePath): array
+{
+    $basePath = dirname(__DIR__, 2);
+    $phpstanBin = escapeshellarg($basePath . '/vendor/bin/phpstan');
+    $configPath = escapeshellarg($basePath . '/tests/PHPStan/Configs/no-assert-see.neon');
+    $file = escapeshellarg($filePath);
+
+    $command = "{$phpstanBin} analyse {$file} --configuration={$configPath} --error-format=json --no-progress 2>&1";
+
+    exec($command, $outputLines, $exitCode);
+
+    return [
+        'exitCode' => $exitCode,
+        'output' => implode("\n", $outputLines),
+    ];
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Adds a custom PHPStan rule banning the usage of testing `assertSee` type methods.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/common/blob/main/README.md#contributing).
